### PR TITLE
Fixed up C++14 build to work in newer CMake versions in arch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,16 @@ enable_testing()
 include(SetupGTest)
 
 # C++ version
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+if ("${CMAKE_VERSION}" LESS "3.1")
+    # This is to support the CMake version backported to Ubuntu 14.04
+    message("CMAKE_VERSION < 3.1, specifying c++14 flag.")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+else()
+    # This is the more modern way of setting our c++ version
+    message("CMAKE_VERSION >= 3.1, setting CMAKE_CXX_STANDARD to 14.")
+    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON) # Don't fall back to older versions
+endif()
 
 # Because we use ninja, we have to explicitly turn on color output for the compiler
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")


### PR DESCRIPTION
Related to [this issue](https://github.com/RoboJackets/robocup-software/issues/787) and to [this pull request](https://github.com/RoboJackets/robocup-software/pull/789) in the robocup-soccer repo.

Fixes up our root CMakeLists file to choose C++14 in a cleaner manner for CMakeLists version >= 3.1.