### PR TITLE
Removed AUR package for ARM cross compilation.

### DIFF
--- a/util/arch-packages-aur.txt
+++ b/util/arch-packages-aur.txt
@@ -1,8 +1,5 @@
 # This is a list of packages that we need for Arch Linux that
 # we'll install from the AUR using yaourt
 
-# mbed compiler suite
-gcc-arm-none-eabi-bin
-
 # optional - needed if you want to use the SpaceNavigator 3d mouse to drive robots
 #spacenavd

--- a/util/arch-packages.txt
+++ b/util/arch-packages.txt
@@ -50,6 +50,11 @@ libspnav
 # joystick library
 sdl
 
+# arm compiler suite
+arm-none-eabi-gcc
+arm-none-eabi-newlib
+arm-none-eabi-gdb
+
 # debugger for MBED code
 arm-none-eabi-gdb
 


### PR DESCRIPTION
I think we had some issues in the past with the arm compiler in the community repos so we were still using one from the AUR which really isn't ideal. The community versions seem to be fixed up and compiling fine now.