### PR TITLE
Will/ramped dribbler

### DIFF
--- a/src/control/modules/ControllerTaskThread.cpp
+++ b/src/control/modules/ControllerTaskThread.cpp
@@ -44,7 +44,7 @@ void Task_Controller_UpdateTarget(Eigen::Vector3f targetVel) {
         commandTimeoutTimer->start(COMMAND_TIMEOUT_INTERVAL);
 }
 
-constexpr uint8_t DRIBBLER_SPEED_UPPERBOUND = 255;
+constexpr uint8_t DRIBBLER_SPEED_UPPERBOUND = 128;
 constexpr uint8_t DRIBBLER_SPEED_LOWERBOUND = 0;
 constexpr float   DRIBBLER_FULL_RAMP_TIME_MS = 500;
 constexpr uint8_t DRIBBLER_MAX_DELTAV_PER_ITER = static_cast<uint8_t>(

--- a/src/control/modules/ControllerTaskThread.cpp
+++ b/src/control/modules/ControllerTaskThread.cpp
@@ -69,8 +69,8 @@ uint8_t get_damped_drib_duty_cycle() {
 
 	// overflows/underflows on unsigned ints don't behave the way we want
 	// a cast is cheaper than more logic based on the reg size of the M3
-	sDribblerSpeed = static_cast<int16_t>(dribblerSpeed);
-	sDribblerSpeedSetPoint = static_cast<int16_t>(dribblerSpeedSetPoint);
+	int16_t sDribblerSpeed = static_cast<int16_t>(dribblerSpeed);
+	int16_t sDribblerSpeedSetPoint = static_cast<int16_t>(dribblerSpeedSetPoint);
 
 	if (dribblerSpeed < dribblerSpeedSetPoint) { // ramp up
 		if (sDribblerSpeed + DRIBBLER_MAX_DELTAV_PER_ITER >= sDribblerSpeedSetPoint) {
@@ -344,7 +344,7 @@ void Task_Controller(const void* args) {
 
         // dribbler duty cycle
         //duty_cycles[4] = dribblerSpeed;
-	duty_cycles[4] = get_damped_drub_duty_cycle();
+	duty_cycles[4] = get_damped_drib_duty_cycle();
 
         Thread::wait(CONTROL_LOOP_WAIT_MS);
     }

--- a/src/control/modules/ControllerTaskThread.cpp
+++ b/src/control/modules/ControllerTaskThread.cpp
@@ -46,11 +46,11 @@ void Task_Controller_UpdateTarget(Eigen::Vector3f targetVel) {
 
 constexpr uint8_t DRIBBLER_SPEED_UPPERBOUND = 128;
 constexpr uint8_t DRIBBLER_SPEED_LOWERBOUND = 0;
-constexpr float   DRIBBLER_FULL_RAMP_TIME_MS = 500;
+constexpr float DRIBBLER_FULL_RAMP_TIME_MS = 500;
 constexpr uint8_t DRIBBLER_MAX_DELTAV_PER_ITER = static_cast<uint8_t>(
-	(static_cast<float>(DRIBBLER_SPEED_UPPERBOUND - DRIBBLER_SPEED_LOWERBOUND) 
-	/ (DRIBBLER_FULL_RAMP_TIME_MS / static_cast<float>(CONTROL_LOOP_WAIT_MS)))
-		+ 1.0f);
+    (static_cast<float>(DRIBBLER_SPEED_UPPERBOUND - DRIBBLER_SPEED_LOWERBOUND) /
+     (DRIBBLER_FULL_RAMP_TIME_MS / static_cast<float>(CONTROL_LOOP_WAIT_MS))) +
+    1.0f);
 
 uint8_t dribblerSpeed = 0;
 uint8_t dribblerSpeedSetPoint = 0;
@@ -62,31 +62,34 @@ void Task_Controller_UpdateDribbler(uint8_t dribbler) {
  *
  */
 uint8_t get_damped_drib_duty_cycle() {
-	// if we're already at the speed we want, return
-	if (dribblerSpeed == dribblerSpeedSetPoint) {
-		return dribblerSpeed;
-	}
+    // if we're already at the speed we want, return
+    if (dribblerSpeed == dribblerSpeedSetPoint) {
+        return dribblerSpeed;
+    }
 
-	// overflows/underflows on unsigned ints don't behave the way we want
-	// a cast is cheaper than more logic based on the reg size of the M3
-	int16_t sDribblerSpeed = static_cast<int16_t>(dribblerSpeed);
-	int16_t sDribblerSpeedSetPoint = static_cast<int16_t>(dribblerSpeedSetPoint);
+    // overflows/underflows on unsigned ints don't behave the way we want
+    // a cast is cheaper than more logic based on the reg size of the M3
+    int16_t sDribblerSpeed = static_cast<int16_t>(dribblerSpeed);
+    int16_t sDribblerSpeedSetPoint =
+        static_cast<int16_t>(dribblerSpeedSetPoint);
 
-	if (dribblerSpeed < dribblerSpeedSetPoint) { // ramp up
-		if (sDribblerSpeed + DRIBBLER_MAX_DELTAV_PER_ITER >= sDribblerSpeedSetPoint) {
-			dribblerSpeed = dribblerSpeedSetPoint;
-		} else {
-			dribblerSpeed += DRIBBLER_MAX_DELTAV_PER_ITER;
-		}
-	} else { // ramp down
-		if (sDribblerSpeed - DRIBBLER_MAX_DELTAV_PER_ITER <= sDribblerSpeedSetPoint) {
-			dribblerSpeed = dribblerSpeedSetPoint;
-		} else {
-			dribblerSpeed -= DRIBBLER_MAX_DELTAV_PER_ITER;
-		}
-	}
+    if (dribblerSpeed < dribblerSpeedSetPoint) {  // ramp up
+        if (sDribblerSpeed + DRIBBLER_MAX_DELTAV_PER_ITER >=
+            sDribblerSpeedSetPoint) {
+            dribblerSpeed = dribblerSpeedSetPoint;
+        } else {
+            dribblerSpeed += DRIBBLER_MAX_DELTAV_PER_ITER;
+        }
+    } else {  // ramp down
+        if (sDribblerSpeed - DRIBBLER_MAX_DELTAV_PER_ITER <=
+            sDribblerSpeedSetPoint) {
+            dribblerSpeed = dribblerSpeedSetPoint;
+        } else {
+            dribblerSpeed -= DRIBBLER_MAX_DELTAV_PER_ITER;
+        }
+    }
 
-	return dribblerSpeed;
+    return dribblerSpeed;
 }
 
 /**
@@ -343,10 +346,9 @@ void Task_Controller(const void* args) {
         }
 
         // dribbler duty cycle
-        //duty_cycles[4] = dribblerSpeed;
-	duty_cycles[4] = get_damped_drib_duty_cycle();
+        // duty_cycles[4] = dribblerSpeed;
+        duty_cycles[4] = get_damped_drib_duty_cycle();
 
         Thread::wait(CONTROL_LOOP_WAIT_MS);
     }
 }
-


### PR DESCRIPTION
This helps to address dribbler motor gearbox damage issues by cheaply limiting the acceleration of the dribbler motor.
 