### PR TITLE
Fix Corruption of End of packet

### DIFF
--- a/lib/drivers/decawave/Decawave.cpp
+++ b/lib/drivers/decawave/Decawave.cpp
@@ -136,7 +136,7 @@ CommLink::BufferT Decawave::getData() {
     if (buf.empty()) return std::move(buf);
 
     // remove the last 2 elements
-    buf.erase(buf.end() - 3, buf.end() - 1);
+    buf.erase(buf.end() - 2, buf.end());
 
     // move the buffer to the caller
     return std::move(buf);


### PR DESCRIPTION
Fix erase iterator to actually erase the last two bytes of the payload instead of the 3rd and 2nd to last.
Fixes #50