### PR TITLE
IMU Integration + Gyro Angle Hold

### DIFF
--- a/lib/drivers/mcp23017/mcp23017.cpp
+++ b/lib/drivers/mcp23017/mcp23017.cpp
@@ -3,8 +3,8 @@
 #include "Logger.hpp"
 #include "Mbed.hpp"
 
-MCP23017::MCP23017(PinName sda, PinName scl, int i2cAddress)
-    : _i2c(sda, scl), _i2cAddress(i2cAddress) {
+MCP23017::MCP23017(std::shared_ptr<SharedI2C> sharedI2C, int i2cAddress)
+    : _i2c(sharedI2C), _i2cAddress(i2cAddress) {
     _i2c.frequency(400000);
     reset();
 }

--- a/lib/drivers/mcp23017/mcp23017.hpp
+++ b/lib/drivers/mcp23017/mcp23017.hpp
@@ -47,7 +47,7 @@ public:
         PinB7 = 15
     } ExpPinName;
 
-    MCP23017(PinName sda, PinName scl, int i2cAddress);
+    MCP23017(std::shared_ptr<SharedI2C> sharedI2C, int i2cAddress);
 
     /** Reset MCP23017 device to its power-on state
      */

--- a/lib/drivers/mpu-6050/I2Cdev.cpp
+++ b/lib/drivers/mpu-6050/I2Cdev.cpp
@@ -1,5 +1,6 @@
 // ported from arduino library: https://github.com/jrowberg/i2cdevlib
-// written by szymon gaertig (email: szymon@gaertig.com.pl, website: szymongaertig.pl)
+// written by szymon gaertig (email: szymon@gaertig.com.pl, website:
+// szymongaertig.pl)
 // Changelog:
 // 2013-01-08 - first release
 
@@ -10,13 +11,15 @@
  * @param regAddr Register regAddr to read from
  * @param bitNum Bit position to read (0-7)
  * @param data Container for single bit value
- * @param timeout Optional read timeout in milliseconds (0 to disable, leave off to use default class value in I2Cdev::readTimeout)
+ * @param timeout Optional read timeout in milliseconds (0 to disable, leave off
+ * to use default class value in I2Cdev::readTimeout)
  * @return Status of read operation (true = success)
  */
-int8_t I2Cdev::readBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint8_t *data, uint16_t timeout) {
+int8_t I2Cdev::readBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum,
+                       uint8_t* data, uint16_t timeout) {
     uint8_t b = 0;
     uint8_t count = readByte(devAddr, regAddr, &b, timeout);
-    *data = b & (1 << bitNum);
+    *data = b&(1 << bitNum);
     return count;
 }
 
@@ -25,13 +28,15 @@ int8_t I2Cdev::readBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint8_t
  * @param regAddr Register regAddr to read from
  * @param bitNum Bit position to read (0-15)
  * @param data Container for single bit value
- * @param timeout Optional read timeout in milliseconds (0 to disable, leave off to use default class value in I2Cdev::readTimeout)
+ * @param timeout Optional read timeout in milliseconds (0 to disable, leave off
+ * to use default class value in I2Cdev::readTimeout)
  * @return Status of read operation (true = success)
  */
-int8_t I2Cdev::readBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint16_t *data, uint16_t timeout) {
+int8_t I2Cdev::readBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum,
+                        uint16_t* data, uint16_t timeout) {
     uint16_t b = 0;
     uint8_t count = readWord(devAddr, regAddr, &b, timeout);
-    *data = b & (1 << bitNum);
+    *data = b&(1 << bitNum);
     return count;
 }
 
@@ -40,11 +45,14 @@ int8_t I2Cdev::readBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint16
  * @param regAddr Register regAddr to read from
  * @param bitStart First bit position to read (0-7)
  * @param length Number of bits to read (not more than 8)
- * @param data Container for right-aligned value (i.e. '101' read from any bitStart position will equal 0x05)
- * @param timeout Optional read timeout in milliseconds (0 to disable, leave off to use default class value in I2Cdev::readTimeout)
+ * @param data Container for right-aligned value (i.e. '101' read from any
+ * bitStart position will equal 0x05)
+ * @param timeout Optional read timeout in milliseconds (0 to disable, leave off
+ * to use default class value in I2Cdev::readTimeout)
  * @return Status of read operation (true = success)
  */
-int8_t I2Cdev::readBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t *data, uint16_t timeout) {
+int8_t I2Cdev::readBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart,
+                        uint8_t length, uint8_t* data, uint16_t timeout) {
     // 01101001 read byte
     // 76543210 bit numbers
     //    xxx   args: bitStart=4, length=3
@@ -65,11 +73,14 @@ int8_t I2Cdev::readBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint
  * @param regAddr Register regAddr to read from
  * @param bitStart First bit position to read (0-15)
  * @param length Number of bits to read (not more than 16)
- * @param data Container for right-aligned value (i.e. '101' read from any bitStart position will equal 0x05)
- * @param timeout Optional read timeout in milliseconds (0 to disable, leave off to use default class value in I2Cdev::readTimeout)
+ * @param data Container for right-aligned value (i.e. '101' read from any
+ * bitStart position will equal 0x05)
+ * @param timeout Optional read timeout in milliseconds (0 to disable, leave off
+ * to use default class value in I2Cdev::readTimeout)
  * @return Status of read operation (1 = success, 0 = failure, -1 = timeout)
  */
-int8_t I2Cdev::readBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint16_t *data, uint16_t timeout) {
+int8_t I2Cdev::readBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart,
+                         uint8_t length, uint16_t* data, uint16_t timeout) {
     // 1101011001101001 read byte
     // fedcba9876543210 bit numbers
     //    xxx           args: bitStart=12, length=3
@@ -89,10 +100,12 @@ int8_t I2Cdev::readBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uin
  * @param devAddr I2C slave device address
  * @param regAddr Register regAddr to read from
  * @param data Container for byte value read from device
- * @param timeout Optional read timeout in milliseconds (0 to disable, leave off to use default class value in I2Cdev::readTimeout)
+ * @param timeout Optional read timeout in milliseconds (0 to disable, leave off
+ * to use default class value in I2Cdev::readTimeout)
  * @return Status of read operation (true = success)
  */
-int8_t I2Cdev::readByte(uint8_t devAddr, uint8_t regAddr, uint8_t *data, uint16_t timeout) {
+int8_t I2Cdev::readByte(uint8_t devAddr, uint8_t regAddr, uint8_t* data,
+                        uint16_t timeout) {
     return readBytes(devAddr, regAddr, 1, data, timeout);
 }
 
@@ -100,10 +113,12 @@ int8_t I2Cdev::readByte(uint8_t devAddr, uint8_t regAddr, uint8_t *data, uint16_
  * @param devAddr I2C slave device address
  * @param regAddr Register regAddr to read from
  * @param data Container for word value read from device
- * @param timeout Optional read timeout in milliseconds (0 to disable, leave off to use default class value in I2Cdev::readTimeout)
+ * @param timeout Optional read timeout in milliseconds (0 to disable, leave off
+ * to use default class value in I2Cdev::readTimeout)
  * @return Status of read operation (true = success)
  */
-int8_t I2Cdev::readWord(uint8_t devAddr, uint8_t regAddr, uint16_t *data, uint16_t timeout) {
+int8_t I2Cdev::readWord(uint8_t devAddr, uint8_t regAddr, uint16_t* data,
+                        uint16_t timeout) {
     return readWords(devAddr, regAddr, 1, data, timeout);
 }
 
@@ -112,25 +127,26 @@ int8_t I2Cdev::readWord(uint8_t devAddr, uint8_t regAddr, uint16_t *data, uint16
  * @param regAddr First register regAddr to read from
  * @param length Number of bytes to read
  * @param data Buffer to store read data in
- * @param timeout Optional read timeout in milliseconds (0 to disable, leave off to use default class value in I2Cdev::readTimeout)
+ * @param timeout Optional read timeout in milliseconds (0 to disable, leave off
+ * to use default class value in I2Cdev::readTimeout)
  * @return Number of bytes read (-1 indicates failure)
  */
-int8_t I2Cdev::readBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_t *data, uint16_t timeout)
-{
+int8_t I2Cdev::readBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length,
+                         uint8_t* data, uint16_t timeout) {
     char command[1];
     command[0] = regAddr;
-    char *redData = (char*)malloc(length);
-    i2c.write(devAddr<<1, command, 1, true);
-    i2c.read(devAddr<<1, redData, length);
-    for(int i =0; i < length; i++) {
+    char* redData = (char*)malloc(length);
+    i2c.write(devAddr << 1, command, 1, true);
+    i2c.read(devAddr << 1, redData, length);
+    for (int i = 0; i < length; i++) {
         data[i] = redData[i];
     }
-    free (redData);
+    free(redData);
     return length;
 }
 
-int8_t I2Cdev::readWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16_t *data, uint16_t timeout)
-{
+int8_t I2Cdev::readWords(uint8_t devAddr, uint8_t regAddr, uint8_t length,
+                         uint16_t* data, uint16_t timeout) {
     return 0;
 }
 
@@ -141,7 +157,8 @@ int8_t I2Cdev::readWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint1
  * @param value New bit value to write
  * @return Status of operation (true = success)
  */
-bool I2Cdev::writeBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint8_t data) {
+bool I2Cdev::writeBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum,
+                      uint8_t data) {
     uint8_t b;
     readByte(devAddr, regAddr, &b);
     b = (data != 0) ? (b | (1 << bitNum)) : (b & ~(1 << bitNum));
@@ -155,7 +172,8 @@ bool I2Cdev::writeBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint8_t 
  * @param value New bit value to write
  * @return Status of operation (true = success)
  */
-bool I2Cdev::writeBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint16_t data) {
+bool I2Cdev::writeBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum,
+                       uint16_t data) {
     uint16_t w = 0;
     readWord(devAddr, regAddr, &w);
     w = (data != 0) ? (w | (1 << bitNum)) : (w & ~(1 << bitNum));
@@ -170,7 +188,8 @@ bool I2Cdev::writeBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint16_
  * @param data Right-aligned value to write
  * @return Status of operation (true = success)
  */
-bool I2Cdev::writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t data) {
+bool I2Cdev::writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart,
+                       uint8_t length, uint8_t data) {
     //      010 value to write
     // 76543210 bit numbers
     //    xxx   args: bitStart=4, length=3
@@ -181,16 +200,14 @@ bool I2Cdev::writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8
     uint8_t b;
     if (readByte(devAddr, regAddr, &b) != 0) {
         uint8_t mask = ((1 << length) - 1) << (bitStart - length + 1);
-        data <<= (bitStart - length + 1); // shift data into correct position
-        data &= mask; // zero all non-important bits in data
-        b &= ~(mask); // zero all important bits in existing byte
-        b |= data; // combine data with existing byte
+        data <<= (bitStart - length + 1);  // shift data into correct position
+        data &= mask;  // zero all non-important bits in data
+        b &= ~(mask);  // zero all important bits in existing byte
+        b |= data;     // combine data with existing byte
         return writeByte(devAddr, regAddr, b);
     } else {
         return false;
     }
-
-
 }
 
 /** Write multiple bits in a 16-bit device register.
@@ -201,7 +218,8 @@ bool I2Cdev::writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8
  * @param data Right-aligned value to write
  * @return Status of operation (true = success)
  */
-bool I2Cdev::writeBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint16_t data) {
+bool I2Cdev::writeBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart,
+                        uint8_t length, uint16_t data) {
     //              010 value to write
     // fedcba9876543210 bit numbers
     //    xxx           args: bitStart=12, length=3
@@ -212,10 +230,10 @@ bool I2Cdev::writeBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint
     uint16_t w;
     if (readWord(devAddr, regAddr, &w) != 0) {
         uint8_t mask = ((1 << length) - 1) << (bitStart - length + 1);
-        data <<= (bitStart - length + 1); // shift data into correct position
-        data &= mask; // zero all non-important bits in data
-        w &= ~(mask); // zero all important bits in existing word
-        w |= data; // combine data with existing word
+        data <<= (bitStart - length + 1);  // shift data into correct position
+        data &= mask;  // zero all non-important bits in data
+        w &= ~(mask);  // zero all important bits in existing word
+        w |= data;     // combine data with existing word
         return writeWord(devAddr, regAddr, w);
     } else {
         return false;
@@ -240,29 +258,29 @@ bool I2Cdev::writeByte(uint8_t devAddr, uint8_t regAddr, uint8_t data) {
  */
 bool I2Cdev::writeWord(uint8_t devAddr, uint8_t regAddr, uint16_t data) {
     i2c.start();
-    i2c.write(devAddr<<1);
+    i2c.write(devAddr << 1);
     i2c.write(regAddr);
-    i2c.write((uint8_t) (data >> 8)); //MSByte
-    i2c.write((uint8_t) (data >> 0)); //LSByte
+    i2c.write((uint8_t)(data >> 8));  // MSByte
+    i2c.write((uint8_t)(data >> 0));  // LSByte
     i2c.stop();
     return true;
-    //return writeWords(devAddr, regAddr, 1, &data);
+    // return writeWords(devAddr, regAddr, 1, &data);
 }
 
-bool I2Cdev::writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_t *data)
-{
+bool I2Cdev::writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length,
+                        uint8_t* data) {
     i2c.start();
-    i2c.write(devAddr<<1);
+    i2c.write(devAddr << 1);
     i2c.write(regAddr);
-    for(int i = 0; i < length; i++) {
+    for (int i = 0; i < length; i++) {
         i2c.write(data[i]);
     }
     i2c.stop();
     return true;
 }
 
-bool I2Cdev::writeWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16_t *data)
-{
+bool I2Cdev::writeWords(uint8_t devAddr, uint8_t regAddr, uint8_t length,
+                        uint16_t* data) {
     // i2c.start();
     // i2c.write(devAddr<<1);
     // i2c.write(regAddr);
@@ -271,36 +289,33 @@ bool I2Cdev::writeWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16
     // // uint8_t bytes[bytes_num];
     // unsigned int i = 1;
     // char *c = (char*)&i;
-    // if (*c)    
-        // printf("Little endian");
+    // if (*c)
+    // printf("Little endian");
     // else
-        // printf("Big endian");
-    
+    // printf("Big endian");
+
     // for (int i = 0; i < length; ++i) {
-        // i2c.write(static_cast<uint8_t>(data[i] && 0xFF));
-        // i2c.write(static_cast<uint8_t>((data[i] >> 8) && 0xFF));
+    // i2c.write(static_cast<uint8_t>(data[i] && 0xFF));
+    // i2c.write(static_cast<uint8_t>((data[i] >> 8) && 0xFF));
     // }
 
     // // uint16_t bytes_pos = 0;
     // // for(int i = 0; i < length; i += 2) {
-        // // bytes[i] = (data[i] >> 8) & 0xFF;
-        // // bytes[i+1] = data[i] & 0xFF;
+    // // bytes[i] = (data[i] >> 8) & 0xFF;
+    // // bytes[i+1] = data[i] & 0xFF;
 
-        // // bytes_pos += 2;
+    // // bytes_pos += 2;
     // // }
 
     // // i2c.write(devAddr, data, length);
 
     // i2c.stop();
-    
+
     // //writeBytes(devAddr, regAddr, length*2, bytes);
 
     return true;
 
-    //return i2c_transmit_nack(dev_addr, bytes, bytes_num);
+    // return i2c_transmit_nack(dev_addr, bytes, bytes_num);
 }
 
-uint16_t I2Cdev::readTimeout(void)
-{
-    return 0;
-}
+uint16_t I2Cdev::readTimeout(void) { return 0; }

--- a/lib/drivers/mpu-6050/I2Cdev.cpp
+++ b/lib/drivers/mpu-6050/I2Cdev.cpp
@@ -5,14 +5,12 @@
 
 #include "I2Cdev.h"
 
-#define useDebugSerial
-
-I2Cdev::I2Cdev(): debugSerial(USBTX, USBRX), i2c(I2C_SDA,I2C_SCL)
+I2Cdev::I2Cdev(): i2c(I2C_SDA,I2C_SCL)
 {
 
 }
 
-I2Cdev::I2Cdev(PinName i2cSda, PinName i2cScl): debugSerial(USBTX, USBRX), i2c(i2cSda,i2cScl)
+I2Cdev::I2Cdev(PinName i2cSda, PinName i2cScl): i2c(i2cSda,i2cScl)
 {
 
 }

--- a/lib/drivers/mpu-6050/I2Cdev.cpp
+++ b/lib/drivers/mpu-6050/I2Cdev.cpp
@@ -5,16 +5,6 @@
 
 #include "I2Cdev.h"
 
-I2Cdev::I2Cdev(): i2c(I2C_SDA,I2C_SCL)
-{
-
-}
-
-I2Cdev::I2Cdev(PinName i2cSda, PinName i2cScl): i2c(i2cSda,i2cScl)
-{
-
-}
-
 /** Read a single bit from an 8-bit device register.
  * @param devAddr I2C slave device address
  * @param regAddr Register regAddr to read from

--- a/lib/drivers/mpu-6050/I2Cdev.h
+++ b/lib/drivers/mpu-6050/I2Cdev.h
@@ -1,8 +1,9 @@
-//ported from arduino library: https://github.com/jrowberg/i2cdevlib/tree/master/Arduino/MPU6050
-//written by szymon gaertig (email: szymon@gaertig.com.pl)
+// ported from arduino library:
+// https://github.com/jrowberg/i2cdevlib/tree/master/Arduino/MPU6050
+// written by szymon gaertig (email: szymon@gaertig.com.pl)
 //
-//Changelog: 
-//2013-01-08 - first beta release
+// Changelog:
+// 2013-01-08 - first beta release
 
 #ifndef I2Cdev_h
 #define I2Cdev_h
@@ -11,30 +12,47 @@
 #include "I2CMasterRtos.hpp"
 
 class I2Cdev {
-    private:
-        I2CMasterRtos i2c;
-    public:
-        I2Cdev(std::shared_ptr<SharedI2C> sharedI2C) : i2c(sharedI2C) {}
-        
-        int8_t readBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint8_t *data, uint16_t timeout=I2Cdev::readTimeout());
-        int8_t readBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint16_t *data, uint16_t timeout=I2Cdev::readTimeout());
-        int8_t readBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t *data, uint16_t timeout=I2Cdev::readTimeout());
-        int8_t readBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint16_t *data, uint16_t timeout=I2Cdev::readTimeout());
-        int8_t readByte(uint8_t devAddr, uint8_t regAddr, uint8_t *data, uint16_t timeout=I2Cdev::readTimeout());
-        int8_t readWord(uint8_t devAddr, uint8_t regAddr, uint16_t *data, uint16_t timeout=I2Cdev::readTimeout());
-        int8_t readBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_t *data, uint16_t timeout=I2Cdev::readTimeout());
-        int8_t readWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16_t *data, uint16_t timeout=I2Cdev::readTimeout());
+private:
+    I2CMasterRtos i2c;
 
-        bool writeBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint8_t data);
-        bool writeBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint16_t data);
-        bool writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t data);
-        bool writeBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint16_t data);
-        bool writeByte(uint8_t devAddr, uint8_t regAddr, uint8_t data);
-        bool writeWord(uint8_t devAddr, uint8_t regAddr, uint16_t data);
-        bool writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_t *data);
-        bool writeWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16_t *data);
+public:
+    I2Cdev(std::shared_ptr<SharedI2C> sharedI2C) : i2c(sharedI2C) {}
 
-        static uint16_t readTimeout(void);
+    int8_t readBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum,
+                   uint8_t* data, uint16_t timeout = I2Cdev::readTimeout());
+    int8_t readBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum,
+                    uint16_t* data, uint16_t timeout = I2Cdev::readTimeout());
+    int8_t readBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart,
+                    uint8_t length, uint8_t* data,
+                    uint16_t timeout = I2Cdev::readTimeout());
+    int8_t readBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart,
+                     uint8_t length, uint16_t* data,
+                     uint16_t timeout = I2Cdev::readTimeout());
+    int8_t readByte(uint8_t devAddr, uint8_t regAddr, uint8_t* data,
+                    uint16_t timeout = I2Cdev::readTimeout());
+    int8_t readWord(uint8_t devAddr, uint8_t regAddr, uint16_t* data,
+                    uint16_t timeout = I2Cdev::readTimeout());
+    int8_t readBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length,
+                     uint8_t* data, uint16_t timeout = I2Cdev::readTimeout());
+    int8_t readWords(uint8_t devAddr, uint8_t regAddr, uint8_t length,
+                     uint16_t* data, uint16_t timeout = I2Cdev::readTimeout());
+
+    bool writeBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum,
+                  uint8_t data);
+    bool writeBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum,
+                   uint16_t data);
+    bool writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart,
+                   uint8_t length, uint8_t data);
+    bool writeBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart,
+                    uint8_t length, uint16_t data);
+    bool writeByte(uint8_t devAddr, uint8_t regAddr, uint8_t data);
+    bool writeWord(uint8_t devAddr, uint8_t regAddr, uint16_t data);
+    bool writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length,
+                    uint8_t* data);
+    bool writeWords(uint8_t devAddr, uint8_t regAddr, uint8_t length,
+                    uint16_t* data);
+
+    static uint16_t readTimeout(void);
 };
 
 #endif

--- a/lib/drivers/mpu-6050/I2Cdev.h
+++ b/lib/drivers/mpu-6050/I2Cdev.h
@@ -14,8 +14,7 @@ class I2Cdev {
     private:
         I2CMasterRtos i2c;
     public:
-        I2Cdev();
-        I2Cdev(PinName i2cSda, PinName i2cScl);        
+        I2Cdev(std::shared_ptr<SharedI2C> sharedI2C) : i2c(sharedI2C) {}
         
         int8_t readBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint8_t *data, uint16_t timeout=I2Cdev::readTimeout());
         int8_t readBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint16_t *data, uint16_t timeout=I2Cdev::readTimeout());

--- a/lib/drivers/mpu-6050/I2Cdev.h
+++ b/lib/drivers/mpu-6050/I2Cdev.h
@@ -12,7 +12,6 @@
 
 class I2Cdev {
     private:
-        Serial debugSerial;
         I2CMasterRtos i2c;
     public:
         I2Cdev();

--- a/lib/drivers/mpu-6050/MPU6050.cpp
+++ b/lib/drivers/mpu-6050/MPU6050.cpp
@@ -39,8 +39,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ===============================================
 */
-
 #include "MPU6050.h"
+
+#include "SharedI2C.hpp"
 
 //instead of using pgmspace.h
 typedef const unsigned char prog_uchar;
@@ -50,9 +51,9 @@ typedef const unsigned char prog_uchar;
 /** Default constructor, uses default I2C address.
  * @see MPU6050_DEFAULT_ADDRESS
  */
-MPU6050::MPU6050()
+MPU6050::MPU6050(std::shared_ptr<SharedI2C> sharedI2C)
 {
-    this->i2Cdev = new I2Cdev(I2C_SDA, I2C_SCL);
+    this->i2Cdev = new I2Cdev(sharedI2C);
     devAddr = MPU6050_DEFAULT_ADDRESS;
 }
 
@@ -64,9 +65,9 @@ MPU6050::MPU6050()
  * @param i2c sda
  * @param i2c scl
  */
-MPU6050::MPU6050(uint8_t address, PinName sda, PinName scl)
+MPU6050::MPU6050(std::shared_ptr<SharedI2C> sharedI2C, uint8_t address)
 {
-    this->i2Cdev = new I2Cdev(sda, scl);
+    this->i2Cdev = new I2Cdev(sharedI2C);
     devAddr = address;
 }
 

--- a/lib/drivers/mpu-6050/MPU6050.cpp
+++ b/lib/drivers/mpu-6050/MPU6050.cpp
@@ -42,8 +42,6 @@ THE SOFTWARE.
 
 #include "MPU6050.h"
 
-// #define useDebugSerial
-
 //instead of using pgmspace.h
 typedef const unsigned char prog_uchar;
 #define pgm_read_byte_near(x) (*(prog_uchar*)x)
@@ -52,7 +50,7 @@ typedef const unsigned char prog_uchar;
 /** Default constructor, uses default I2C address.
  * @see MPU6050_DEFAULT_ADDRESS
  */
-MPU6050::MPU6050() : debugSerial(USBTX, USBRX)
+MPU6050::MPU6050()
 {
     this->i2Cdev = new I2Cdev(I2C_SDA, I2C_SCL);
     devAddr = MPU6050_DEFAULT_ADDRESS;
@@ -66,7 +64,7 @@ MPU6050::MPU6050() : debugSerial(USBTX, USBRX)
  * @param i2c sda
  * @param i2c scl
  */
-MPU6050::MPU6050(uint8_t address, PinName sda, PinName scl) : debugSerial(USBTX, USBRX)
+MPU6050::MPU6050(uint8_t address, PinName sda, PinName scl)
 {
     this->i2Cdev = new I2Cdev(sda, scl);
     devAddr = address;
@@ -81,19 +79,11 @@ MPU6050::MPU6050(uint8_t address, PinName sda, PinName scl) : debugSerial(USBTX,
  */
 void MPU6050::initialize()
 {
-
-#ifdef useDebugSerial
-    debugSerial.printf("MPU6050::initialize start\n");
-#endif
-
     setClockSource(MPU6050_CLOCK_PLL_XGYRO);
     setFullScaleGyroRange(MPU6050_GYRO_FS_250);
     setFullScaleAccelRange(MPU6050_ACCEL_FS_2);
     setSleepEnabled(false); // thanks to Jack Elston for pointing this one out!
 
-#ifdef useDebugSerial
-    debugSerial.printf("MPU6050::initialize end\n");
-#endif
 }
 
 /** Verify the I2C connection.
@@ -102,13 +92,7 @@ void MPU6050::initialize()
  */
 bool MPU6050::testConnection()
 {
-#ifdef useDebugSerial
-    debugSerial.printf("MPU6050::testConnection start\n");
-#endif
     uint8_t deviceId = getDeviceID();
-#ifdef useDebugSerial
-    debugSerial.printf("DeviceId = %d\n",deviceId);
-#endif
     printf("deviceID = %d\n", deviceId);
     return deviceId == 0x34;
 }

--- a/lib/drivers/mpu-6050/MPU6050.cpp
+++ b/lib/drivers/mpu-6050/MPU6050.cpp
@@ -1,19 +1,24 @@
-//ported from arduino library: https://github.com/jrowberg/i2cdevlib/tree/master/Arduino/MPU6050
-//written by szymon gaertig (email: szymon@gaertig.com.pl)
+// ported from arduino library:
+// https://github.com/jrowberg/i2cdevlib/tree/master/Arduino/MPU6050
+// written by szymon gaertig (email: szymon@gaertig.com.pl)
 //
-//Changelog:
-//2013-01-08 - first beta release
+// Changelog:
+// 2013-01-08 - first beta release
 
 // I2Cdev library collection - MPU6050 I2C device class
-// Based on InvenSense MPU-6050 register map document rev. 2.0, 5/19/2011 (RM-MPU-6000A-00)
+// Based on InvenSense MPU-6050 register map document rev. 2.0, 5/19/2011
+// (RM-MPU-6000A-00)
 // 8/24/2011 by Jeff Rowberg <jeff@rowberg.net>
-// Updates should (hopefully) always be available at https://github.com/jrowberg/i2cdevlib
+// Updates should (hopefully) always be available at
+// https://github.com/jrowberg/i2cdevlib
 //
 // Changelog:
 //     ... - ongoing debug release
 
-// NOTE: THIS IS ONLY A PARIAL RELEASE. THIS DEVICE CLASS IS CURRENTLY UNDERGOING ACTIVE
-// DEVELOPMENT AND IS STILL MISSING SOME IMPORTANT FEATURES. PLEASE KEEP THIS IN MIND IF
+// NOTE: THIS IS ONLY A PARIAL RELEASE. THIS DEVICE CLASS IS CURRENTLY
+// UNDERGOING ACTIVE
+// DEVELOPMENT AND IS STILL MISSING SOME IMPORTANT FEATURES. PLEASE KEEP THIS IN
+// MIND IF
 // YOU DECIDE TO USE THIS PARTICULAR CODE FOR ANYTHING.
 
 /* ============================================
@@ -43,7 +48,7 @@ THE SOFTWARE.
 
 #include "SharedI2C.hpp"
 
-//instead of using pgmspace.h
+// instead of using pgmspace.h
 typedef const unsigned char prog_uchar;
 #define pgm_read_byte_near(x) (*(prog_uchar*)x)
 #define pgm_read_byte(x) (*(prog_uchar*)x)
@@ -51,8 +56,7 @@ typedef const unsigned char prog_uchar;
 /** Default constructor, uses default I2C address.
  * @see MPU6050_DEFAULT_ADDRESS
  */
-MPU6050::MPU6050(std::shared_ptr<SharedI2C> sharedI2C)
-{
+MPU6050::MPU6050(std::shared_ptr<SharedI2C> sharedI2C) {
     this->i2Cdev = new I2Cdev(sharedI2C);
     devAddr = MPU6050_DEFAULT_ADDRESS;
 }
@@ -65,34 +69,34 @@ MPU6050::MPU6050(std::shared_ptr<SharedI2C> sharedI2C)
  * @param i2c sda
  * @param i2c scl
  */
-MPU6050::MPU6050(std::shared_ptr<SharedI2C> sharedI2C, uint8_t address)
-{
+MPU6050::MPU6050(std::shared_ptr<SharedI2C> sharedI2C, uint8_t address) {
     this->i2Cdev = new I2Cdev(sharedI2C);
     devAddr = address;
 }
 
 /** Power on and prepare for general usage.
- * This will activate the device and take it out of sleep mode (which must be done
- * after start-up). This function also sets both the accelerometer and the gyroscope
- * to their most sensitive settings, namely +/- 2g and +/- 250 degrees/sec, and sets
- * the clock source to use the X Gyro for reference, which is slightly better than
+ * This will activate the device and take it out of sleep mode (which must be
+ * done
+ * after start-up). This function also sets both the accelerometer and the
+ * gyroscope
+ * to their most sensitive settings, namely +/- 2g and +/- 250 degrees/sec, and
+ * sets
+ * the clock source to use the X Gyro for reference, which is slightly better
+ * than
  * the default internal clock source.
  */
-void MPU6050::initialize()
-{
+void MPU6050::initialize() {
     setClockSource(MPU6050_CLOCK_PLL_XGYRO);
     setFullScaleGyroRange(MPU6050_GYRO_FS_250);
     setFullScaleAccelRange(MPU6050_ACCEL_FS_2);
-    setSleepEnabled(false); // thanks to Jack Elston for pointing this one out!
-
+    setSleepEnabled(false);  // thanks to Jack Elston for pointing this one out!
 }
 
 /** Verify the I2C connection.
  * Make sure the device is connected and responds as expected.
  * @return True if connection is valid, false otherwise
  */
-bool MPU6050::testConnection()
-{
+bool MPU6050::testConnection() {
     uint8_t deviceId = getDeviceID();
     printf("deviceID = %d\n", deviceId);
     return deviceId == 0x34;
@@ -106,9 +110,9 @@ bool MPU6050::testConnection()
  * the MPU-6000, which does not have a VLOGIC pin.
  * @return I2C supply voltage level (0=VLOGIC, 1=VDD)
  */
-uint8_t MPU6050::getAuxVDDIOLevel()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_YG_OFFS_TC, MPU6050_TC_PWR_MODE_BIT, buffer);
+uint8_t MPU6050::getAuxVDDIOLevel() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_YG_OFFS_TC, MPU6050_TC_PWR_MODE_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set the auxiliary I2C supply voltage level.
@@ -117,9 +121,9 @@ uint8_t MPU6050::getAuxVDDIOLevel()
  * the MPU-6000, which does not have a VLOGIC pin.
  * @param level I2C supply voltage level (0=VLOGIC, 1=VDD)
  */
-void MPU6050::setAuxVDDIOLevel(uint8_t level)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_YG_OFFS_TC, MPU6050_TC_PWR_MODE_BIT, level);
+void MPU6050::setAuxVDDIOLevel(uint8_t level) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_YG_OFFS_TC, MPU6050_TC_PWR_MODE_BIT,
+                     level);
 }
 
 // SMPLRT_DIV register
@@ -145,8 +149,7 @@ void MPU6050::setAuxVDDIOLevel(uint8_t level)
  * @return Current sample rate
  * @see MPU6050_RA_SMPLRT_DIV
  */
-uint8_t MPU6050::getRate()
-{
+uint8_t MPU6050::getRate() {
     i2Cdev->readByte(devAddr, MPU6050_RA_SMPLRT_DIV, buffer);
     return buffer[0];
 }
@@ -155,8 +158,7 @@ uint8_t MPU6050::getRate()
  * @see getRate()
  * @see MPU6050_RA_SMPLRT_DIV
  */
-void MPU6050::setRate(uint8_t rate)
-{
+void MPU6050::setRate(uint8_t rate) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_SMPLRT_DIV, rate);
 }
 
@@ -189,9 +191,9 @@ void MPU6050::setRate(uint8_t rate)
  *
  * @return FSYNC configuration value
  */
-uint8_t MPU6050::getExternalFrameSync()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_CONFIG, MPU6050_CFG_EXT_SYNC_SET_BIT, MPU6050_CFG_EXT_SYNC_SET_LENGTH, buffer);
+uint8_t MPU6050::getExternalFrameSync() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_CONFIG, MPU6050_CFG_EXT_SYNC_SET_BIT,
+                     MPU6050_CFG_EXT_SYNC_SET_LENGTH, buffer);
     return buffer[0];
 }
 /** Set external FSYNC configuration.
@@ -199,9 +201,9 @@ uint8_t MPU6050::getExternalFrameSync()
  * @see MPU6050_RA_CONFIG
  * @param sync New FSYNC configuration value
  */
-void MPU6050::setExternalFrameSync(uint8_t sync)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_CONFIG, MPU6050_CFG_EXT_SYNC_SET_BIT, MPU6050_CFG_EXT_SYNC_SET_LENGTH, sync);
+void MPU6050::setExternalFrameSync(uint8_t sync) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_CONFIG, MPU6050_CFG_EXT_SYNC_SET_BIT,
+                      MPU6050_CFG_EXT_SYNC_SET_LENGTH, sync);
 }
 /** Get digital low-pass filter configuration.
  * The DLPF_CFG parameter sets the digital low pass filter configuration. It
@@ -231,9 +233,9 @@ void MPU6050::setExternalFrameSync(uint8_t sync)
  * @see MPU6050_CFG_DLPF_CFG_BIT
  * @see MPU6050_CFG_DLPF_CFG_LENGTH
  */
-uint8_t MPU6050::getDLPFMode()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_CONFIG, MPU6050_CFG_DLPF_CFG_BIT, MPU6050_CFG_DLPF_CFG_LENGTH, buffer);
+uint8_t MPU6050::getDLPFMode() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_CONFIG, MPU6050_CFG_DLPF_CFG_BIT,
+                     MPU6050_CFG_DLPF_CFG_LENGTH, buffer);
     return buffer[0];
 }
 /** Set digital low-pass filter configuration.
@@ -244,9 +246,9 @@ uint8_t MPU6050::getDLPFMode()
  * @see MPU6050_CFG_DLPF_CFG_BIT
  * @see MPU6050_CFG_DLPF_CFG_LENGTH
  */
-void MPU6050::setDLPFMode(uint8_t mode)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_CONFIG, MPU6050_CFG_DLPF_CFG_BIT, MPU6050_CFG_DLPF_CFG_LENGTH, mode);
+void MPU6050::setDLPFMode(uint8_t mode) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_CONFIG, MPU6050_CFG_DLPF_CFG_BIT,
+                      MPU6050_CFG_DLPF_CFG_LENGTH, mode);
 }
 
 // GYRO_CONFIG register
@@ -268,9 +270,10 @@ void MPU6050::setDLPFMode(uint8_t mode)
  * @see MPU6050_GCONFIG_FS_SEL_BIT
  * @see MPU6050_GCONFIG_FS_SEL_LENGTH
  */
-uint8_t MPU6050::getFullScaleGyroRange()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_GYRO_CONFIG, MPU6050_GCONFIG_FS_SEL_BIT, MPU6050_GCONFIG_FS_SEL_LENGTH, buffer);
+uint8_t MPU6050::getFullScaleGyroRange() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_GYRO_CONFIG,
+                     MPU6050_GCONFIG_FS_SEL_BIT, MPU6050_GCONFIG_FS_SEL_LENGTH,
+                     buffer);
     return buffer[0];
 }
 /** Set full-scale gyroscope range.
@@ -281,9 +284,10 @@ uint8_t MPU6050::getFullScaleGyroRange()
  * @see MPU6050_GCONFIG_FS_SEL_BIT
  * @see MPU6050_GCONFIG_FS_SEL_LENGTH
  */
-void MPU6050::setFullScaleGyroRange(uint8_t range)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_GYRO_CONFIG, MPU6050_GCONFIG_FS_SEL_BIT, MPU6050_GCONFIG_FS_SEL_LENGTH, range);
+void MPU6050::setFullScaleGyroRange(uint8_t range) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_GYRO_CONFIG,
+                      MPU6050_GCONFIG_FS_SEL_BIT, MPU6050_GCONFIG_FS_SEL_LENGTH,
+                      range);
 }
 
 // ACCEL_CONFIG register
@@ -292,52 +296,52 @@ void MPU6050::setFullScaleGyroRange(uint8_t range)
  * @return Self-test enabled value
  * @see MPU6050_RA_ACCEL_CONFIG
  */
-bool MPU6050::getAccelXSelfTest()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_XA_ST_BIT, buffer);
+bool MPU6050::getAccelXSelfTest() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_XA_ST_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Get self-test enabled setting for accelerometer X axis.
  * @param enabled Self-test enabled value
  * @see MPU6050_RA_ACCEL_CONFIG
  */
-void MPU6050::setAccelXSelfTest(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_XA_ST_BIT, enabled);
+void MPU6050::setAccelXSelfTest(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_ACCEL_CONFIG,
+                     MPU6050_ACONFIG_XA_ST_BIT, enabled);
 }
 /** Get self-test enabled value for accelerometer Y axis.
  * @return Self-test enabled value
  * @see MPU6050_RA_ACCEL_CONFIG
  */
-bool MPU6050::getAccelYSelfTest()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_YA_ST_BIT, buffer);
+bool MPU6050::getAccelYSelfTest() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_YA_ST_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Get self-test enabled value for accelerometer Y axis.
  * @param enabled Self-test enabled value
  * @see MPU6050_RA_ACCEL_CONFIG
  */
-void MPU6050::setAccelYSelfTest(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_YA_ST_BIT, enabled);
+void MPU6050::setAccelYSelfTest(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_ACCEL_CONFIG,
+                     MPU6050_ACONFIG_YA_ST_BIT, enabled);
 }
 /** Get self-test enabled value for accelerometer Z axis.
  * @return Self-test enabled value
  * @see MPU6050_RA_ACCEL_CONFIG
  */
-bool MPU6050::getAccelZSelfTest()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_ZA_ST_BIT, buffer);
+bool MPU6050::getAccelZSelfTest() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_ZA_ST_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set self-test enabled value for accelerometer Z axis.
  * @param enabled Self-test enabled value
  * @see MPU6050_RA_ACCEL_CONFIG
  */
-void MPU6050::setAccelZSelfTest(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_ZA_ST_BIT, enabled);
+void MPU6050::setAccelZSelfTest(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_ACCEL_CONFIG,
+                     MPU6050_ACONFIG_ZA_ST_BIT, enabled);
 }
 /** Get full-scale accelerometer range.
  * The FS_SEL parameter allows setting the full-scale range of the accelerometer
@@ -356,18 +360,20 @@ void MPU6050::setAccelZSelfTest(bool enabled)
  * @see MPU6050_ACONFIG_AFS_SEL_BIT
  * @see MPU6050_ACONFIG_AFS_SEL_LENGTH
  */
-uint8_t MPU6050::getFullScaleAccelRange()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_AFS_SEL_BIT, MPU6050_ACONFIG_AFS_SEL_LENGTH, buffer);
+uint8_t MPU6050::getFullScaleAccelRange() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_ACCEL_CONFIG,
+                     MPU6050_ACONFIG_AFS_SEL_BIT,
+                     MPU6050_ACONFIG_AFS_SEL_LENGTH, buffer);
     return buffer[0];
 }
 /** Set full-scale accelerometer range.
  * @param range New full-scale accelerometer range setting
  * @see getFullScaleAccelRange()
  */
-void MPU6050::setFullScaleAccelRange(uint8_t range)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_AFS_SEL_BIT, MPU6050_ACONFIG_AFS_SEL_LENGTH, range);
+void MPU6050::setFullScaleAccelRange(uint8_t range) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_ACCEL_CONFIG,
+                      MPU6050_ACONFIG_AFS_SEL_BIT,
+                      MPU6050_ACONFIG_AFS_SEL_LENGTH, range);
 }
 /** Get the high-pass filter configuration.
  * The DHPF is a filter module in the path leading to motion detectors (Free
@@ -404,9 +410,10 @@ void MPU6050::setFullScaleAccelRange(uint8_t range)
  * @see MPU6050_DHPF_RESET
  * @see MPU6050_RA_ACCEL_CONFIG
  */
-uint8_t MPU6050::getDHPFMode()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_ACCEL_HPF_BIT, MPU6050_ACONFIG_ACCEL_HPF_LENGTH, buffer);
+uint8_t MPU6050::getDHPFMode() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_ACCEL_CONFIG,
+                     MPU6050_ACONFIG_ACCEL_HPF_BIT,
+                     MPU6050_ACONFIG_ACCEL_HPF_LENGTH, buffer);
     return buffer[0];
 }
 /** Set the high-pass filter configuration.
@@ -415,9 +422,10 @@ uint8_t MPU6050::getDHPFMode()
  * @see MPU6050_DHPF_RESET
  * @see MPU6050_RA_ACCEL_CONFIG
  */
-void MPU6050::setDHPFMode(uint8_t bandwidth)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_ACCEL_CONFIG, MPU6050_ACONFIG_ACCEL_HPF_BIT, MPU6050_ACONFIG_ACCEL_HPF_LENGTH, bandwidth);
+void MPU6050::setDHPFMode(uint8_t bandwidth) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_ACCEL_CONFIG,
+                      MPU6050_ACONFIG_ACCEL_HPF_BIT,
+                      MPU6050_ACONFIG_ACCEL_HPF_LENGTH, bandwidth);
 }
 
 // FF_THR register
@@ -437,8 +445,7 @@ void MPU6050::setDHPFMode(uint8_t bandwidth)
  * @return Current free-fall acceleration threshold value (LSB = 2mg)
  * @see MPU6050_RA_FF_THR
  */
-uint8_t MPU6050::getFreefallDetectionThreshold()
-{
+uint8_t MPU6050::getFreefallDetectionThreshold() {
     i2Cdev->readByte(devAddr, MPU6050_RA_FF_THR, buffer);
     return buffer[0];
 }
@@ -447,8 +454,7 @@ uint8_t MPU6050::getFreefallDetectionThreshold()
  * @see getFreefallDetectionThreshold()
  * @see MPU6050_RA_FF_THR
  */
-void MPU6050::setFreefallDetectionThreshold(uint8_t threshold)
-{
+void MPU6050::setFreefallDetectionThreshold(uint8_t threshold) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_FF_THR, threshold);
 }
 
@@ -471,8 +477,7 @@ void MPU6050::setFreefallDetectionThreshold(uint8_t threshold)
  * @return Current free-fall duration threshold value (LSB = 1ms)
  * @see MPU6050_RA_FF_DUR
  */
-uint8_t MPU6050::getFreefallDetectionDuration()
-{
+uint8_t MPU6050::getFreefallDetectionDuration() {
     i2Cdev->readByte(devAddr, MPU6050_RA_FF_DUR, buffer);
     return buffer[0];
 }
@@ -481,8 +486,7 @@ uint8_t MPU6050::getFreefallDetectionDuration()
  * @see getFreefallDetectionDuration()
  * @see MPU6050_RA_FF_DUR
  */
-void MPU6050::setFreefallDetectionDuration(uint8_t duration)
-{
+void MPU6050::setFreefallDetectionDuration(uint8_t duration) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_FF_DUR, duration);
 }
 
@@ -507,18 +511,17 @@ void MPU6050::setFreefallDetectionDuration(uint8_t duration)
  * @return Current motion detection acceleration threshold value (LSB = 2mg)
  * @see MPU6050_RA_MOT_THR
  */
-uint8_t MPU6050::getMotionDetectionThreshold()
-{
+uint8_t MPU6050::getMotionDetectionThreshold() {
     i2Cdev->readByte(devAddr, MPU6050_RA_MOT_THR, buffer);
     return buffer[0];
 }
 /** Set free-fall event acceleration threshold.
- * @param threshold New motion detection acceleration threshold value (LSB = 2mg)
+ * @param threshold New motion detection acceleration threshold value (LSB =
+ * 2mg)
  * @see getMotionDetectionThreshold()
  * @see MPU6050_RA_MOT_THR
  */
-void MPU6050::setMotionDetectionThreshold(uint8_t threshold)
-{
+void MPU6050::setMotionDetectionThreshold(uint8_t threshold) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_MOT_THR, threshold);
 }
 
@@ -539,8 +542,7 @@ void MPU6050::setMotionDetectionThreshold(uint8_t threshold)
  * @return Current motion detection duration threshold value (LSB = 1ms)
  * @see MPU6050_RA_MOT_DUR
  */
-uint8_t MPU6050::getMotionDetectionDuration()
-{
+uint8_t MPU6050::getMotionDetectionDuration() {
     i2Cdev->readByte(devAddr, MPU6050_RA_MOT_DUR, buffer);
     return buffer[0];
 }
@@ -549,8 +551,7 @@ uint8_t MPU6050::getMotionDetectionDuration()
  * @see getMotionDetectionDuration()
  * @see MPU6050_RA_MOT_DUR
  */
-void MPU6050::setMotionDetectionDuration(uint8_t duration)
-{
+void MPU6050::setMotionDetectionDuration(uint8_t duration) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_MOT_DUR, duration);
 }
 
@@ -578,21 +579,21 @@ void MPU6050::setMotionDetectionDuration(uint8_t duration)
  * the MPU-6000/MPU-6050 Product Specification document as well as Registers 56
  * and 58 of this document.
  *
- * @return Current zero motion detection acceleration threshold value (LSB = 2mg)
+ * @return Current zero motion detection acceleration threshold value (LSB =
+ *2mg)
  * @see MPU6050_RA_ZRMOT_THR
  */
-uint8_t MPU6050::getZeroMotionDetectionThreshold()
-{
+uint8_t MPU6050::getZeroMotionDetectionThreshold() {
     i2Cdev->readByte(devAddr, MPU6050_RA_ZRMOT_THR, buffer);
     return buffer[0];
 }
 /** Set zero motion detection event acceleration threshold.
- * @param threshold New zero motion detection acceleration threshold value (LSB = 2mg)
+ * @param threshold New zero motion detection acceleration threshold value (LSB
+ * = 2mg)
  * @see getZeroMotionDetectionThreshold()
  * @see MPU6050_RA_ZRMOT_THR
  */
-void MPU6050::setZeroMotionDetectionThreshold(uint8_t threshold)
-{
+void MPU6050::setZeroMotionDetectionThreshold(uint8_t threshold) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_ZRMOT_THR, threshold);
 }
 
@@ -614,18 +615,17 @@ void MPU6050::setZeroMotionDetectionThreshold(uint8_t threshold)
  * @return Current zero motion detection duration threshold value (LSB = 64ms)
  * @see MPU6050_RA_ZRMOT_DUR
  */
-uint8_t MPU6050::getZeroMotionDetectionDuration()
-{
+uint8_t MPU6050::getZeroMotionDetectionDuration() {
     i2Cdev->readByte(devAddr, MPU6050_RA_ZRMOT_DUR, buffer);
     return buffer[0];
 }
 /** Set zero motion detection event duration threshold.
- * @param duration New zero motion detection duration threshold value (LSB = 1ms)
+ * @param duration New zero motion detection duration threshold value (LSB =
+ * 1ms)
  * @see getZeroMotionDetectionDuration()
  * @see MPU6050_RA_ZRMOT_DUR
  */
-void MPU6050::setZeroMotionDetectionDuration(uint8_t duration)
-{
+void MPU6050::setZeroMotionDetectionDuration(uint8_t duration) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_ZRMOT_DUR, duration);
 }
 
@@ -637,9 +637,9 @@ void MPU6050::setZeroMotionDetectionDuration(uint8_t duration)
  * @return Current temperature FIFO enabled value
  * @see MPU6050_RA_FIFO_EN
  */
-bool MPU6050::getTempFIFOEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_TEMP_FIFO_EN_BIT, buffer);
+bool MPU6050::getTempFIFOEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_TEMP_FIFO_EN_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set temperature FIFO enabled value.
@@ -647,9 +647,9 @@ bool MPU6050::getTempFIFOEnabled()
  * @see getTempFIFOEnabled()
  * @see MPU6050_RA_FIFO_EN
  */
-void MPU6050::setTempFIFOEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_TEMP_FIFO_EN_BIT, enabled);
+void MPU6050::setTempFIFOEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_TEMP_FIFO_EN_BIT,
+                     enabled);
 }
 /** Get gyroscope X-axis FIFO enabled value.
  * When set to 1, this bit enables GYRO_XOUT_H and GYRO_XOUT_L (Registers 67 and
@@ -657,9 +657,9 @@ void MPU6050::setTempFIFOEnabled(bool enabled)
  * @return Current gyroscope X-axis FIFO enabled value
  * @see MPU6050_RA_FIFO_EN
  */
-bool MPU6050::getXGyroFIFOEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_XG_FIFO_EN_BIT, buffer);
+bool MPU6050::getXGyroFIFOEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_XG_FIFO_EN_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set gyroscope X-axis FIFO enabled value.
@@ -667,9 +667,9 @@ bool MPU6050::getXGyroFIFOEnabled()
  * @see getXGyroFIFOEnabled()
  * @see MPU6050_RA_FIFO_EN
  */
-void MPU6050::setXGyroFIFOEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_XG_FIFO_EN_BIT, enabled);
+void MPU6050::setXGyroFIFOEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_XG_FIFO_EN_BIT,
+                     enabled);
 }
 /** Get gyroscope Y-axis FIFO enabled value.
  * When set to 1, this bit enables GYRO_YOUT_H and GYRO_YOUT_L (Registers 69 and
@@ -677,9 +677,9 @@ void MPU6050::setXGyroFIFOEnabled(bool enabled)
  * @return Current gyroscope Y-axis FIFO enabled value
  * @see MPU6050_RA_FIFO_EN
  */
-bool MPU6050::getYGyroFIFOEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_YG_FIFO_EN_BIT, buffer);
+bool MPU6050::getYGyroFIFOEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_YG_FIFO_EN_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set gyroscope Y-axis FIFO enabled value.
@@ -687,9 +687,9 @@ bool MPU6050::getYGyroFIFOEnabled()
  * @see getYGyroFIFOEnabled()
  * @see MPU6050_RA_FIFO_EN
  */
-void MPU6050::setYGyroFIFOEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_YG_FIFO_EN_BIT, enabled);
+void MPU6050::setYGyroFIFOEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_YG_FIFO_EN_BIT,
+                     enabled);
 }
 /** Get gyroscope Z-axis FIFO enabled value.
  * When set to 1, this bit enables GYRO_ZOUT_H and GYRO_ZOUT_L (Registers 71 and
@@ -697,9 +697,9 @@ void MPU6050::setYGyroFIFOEnabled(bool enabled)
  * @return Current gyroscope Z-axis FIFO enabled value
  * @see MPU6050_RA_FIFO_EN
  */
-bool MPU6050::getZGyroFIFOEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_ZG_FIFO_EN_BIT, buffer);
+bool MPU6050::getZGyroFIFOEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_ZG_FIFO_EN_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set gyroscope Z-axis FIFO enabled value.
@@ -707,9 +707,9 @@ bool MPU6050::getZGyroFIFOEnabled()
  * @see getZGyroFIFOEnabled()
  * @see MPU6050_RA_FIFO_EN
  */
-void MPU6050::setZGyroFIFOEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_ZG_FIFO_EN_BIT, enabled);
+void MPU6050::setZGyroFIFOEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_ZG_FIFO_EN_BIT,
+                     enabled);
 }
 /** Get accelerometer FIFO enabled value.
  * When set to 1, this bit enables ACCEL_XOUT_H, ACCEL_XOUT_L, ACCEL_YOUT_H,
@@ -718,9 +718,9 @@ void MPU6050::setZGyroFIFOEnabled(bool enabled)
  * @return Current accelerometer FIFO enabled value
  * @see MPU6050_RA_FIFO_EN
  */
-bool MPU6050::getAccelFIFOEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_ACCEL_FIFO_EN_BIT, buffer);
+bool MPU6050::getAccelFIFOEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_ACCEL_FIFO_EN_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set accelerometer FIFO enabled value.
@@ -728,9 +728,9 @@ bool MPU6050::getAccelFIFOEnabled()
  * @see getAccelFIFOEnabled()
  * @see MPU6050_RA_FIFO_EN
  */
-void MPU6050::setAccelFIFOEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_ACCEL_FIFO_EN_BIT, enabled);
+void MPU6050::setAccelFIFOEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_ACCEL_FIFO_EN_BIT,
+                     enabled);
 }
 /** Get Slave 2 FIFO enabled value.
  * When set to 1, this bit enables EXT_SENS_DATA registers (Registers 73 to 96)
@@ -738,9 +738,9 @@ void MPU6050::setAccelFIFOEnabled(bool enabled)
  * @return Current Slave 2 FIFO enabled value
  * @see MPU6050_RA_FIFO_EN
  */
-bool MPU6050::getSlave2FIFOEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_SLV2_FIFO_EN_BIT, buffer);
+bool MPU6050::getSlave2FIFOEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_SLV2_FIFO_EN_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set Slave 2 FIFO enabled value.
@@ -748,9 +748,9 @@ bool MPU6050::getSlave2FIFOEnabled()
  * @see getSlave2FIFOEnabled()
  * @see MPU6050_RA_FIFO_EN
  */
-void MPU6050::setSlave2FIFOEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_SLV2_FIFO_EN_BIT, enabled);
+void MPU6050::setSlave2FIFOEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_SLV2_FIFO_EN_BIT,
+                     enabled);
 }
 /** Get Slave 1 FIFO enabled value.
  * When set to 1, this bit enables EXT_SENS_DATA registers (Registers 73 to 96)
@@ -758,9 +758,9 @@ void MPU6050::setSlave2FIFOEnabled(bool enabled)
  * @return Current Slave 1 FIFO enabled value
  * @see MPU6050_RA_FIFO_EN
  */
-bool MPU6050::getSlave1FIFOEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_SLV1_FIFO_EN_BIT, buffer);
+bool MPU6050::getSlave1FIFOEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_SLV1_FIFO_EN_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set Slave 1 FIFO enabled value.
@@ -768,9 +768,9 @@ bool MPU6050::getSlave1FIFOEnabled()
  * @see getSlave1FIFOEnabled()
  * @see MPU6050_RA_FIFO_EN
  */
-void MPU6050::setSlave1FIFOEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_SLV1_FIFO_EN_BIT, enabled);
+void MPU6050::setSlave1FIFOEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_SLV1_FIFO_EN_BIT,
+                     enabled);
 }
 /** Get Slave 0 FIFO enabled value.
  * When set to 1, this bit enables EXT_SENS_DATA registers (Registers 73 to 96)
@@ -778,9 +778,9 @@ void MPU6050::setSlave1FIFOEnabled(bool enabled)
  * @return Current Slave 0 FIFO enabled value
  * @see MPU6050_RA_FIFO_EN
  */
-bool MPU6050::getSlave0FIFOEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_SLV0_FIFO_EN_BIT, buffer);
+bool MPU6050::getSlave0FIFOEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_SLV0_FIFO_EN_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set Slave 0 FIFO enabled value.
@@ -788,9 +788,9 @@ bool MPU6050::getSlave0FIFOEnabled()
  * @see getSlave0FIFOEnabled()
  * @see MPU6050_RA_FIFO_EN
  */
-void MPU6050::setSlave0FIFOEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_SLV0_FIFO_EN_BIT, enabled);
+void MPU6050::setSlave0FIFOEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_FIFO_EN, MPU6050_SLV0_FIFO_EN_BIT,
+                     enabled);
 }
 
 // I2C_MST_CTRL register
@@ -810,9 +810,9 @@ void MPU6050::setSlave0FIFOEnabled(bool enabled)
  * @return Current multi-master enabled value
  * @see MPU6050_RA_I2C_MST_CTRL
  */
-bool MPU6050::getMultiMasterEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_MULT_MST_EN_BIT, buffer);
+bool MPU6050::getMultiMasterEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_MULT_MST_EN_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set multi-master enabled value.
@@ -820,9 +820,9 @@ bool MPU6050::getMultiMasterEnabled()
  * @see getMultiMasterEnabled()
  * @see MPU6050_RA_I2C_MST_CTRL
  */
-void MPU6050::setMultiMasterEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_MULT_MST_EN_BIT, enabled);
+void MPU6050::setMultiMasterEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_MULT_MST_EN_BIT,
+                     enabled);
 }
 /** Get wait-for-external-sensor-data enabled value.
  * When the WAIT_FOR_ES bit is set to 1, the Data Ready interrupt will be
@@ -835,9 +835,9 @@ void MPU6050::setMultiMasterEnabled(bool enabled)
  * @return Current wait-for-external-sensor-data enabled value
  * @see MPU6050_RA_I2C_MST_CTRL
  */
-bool MPU6050::getWaitForExternalSensorEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_WAIT_FOR_ES_BIT, buffer);
+bool MPU6050::getWaitForExternalSensorEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_WAIT_FOR_ES_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set wait-for-external-sensor-data enabled value.
@@ -845,9 +845,9 @@ bool MPU6050::getWaitForExternalSensorEnabled()
  * @see getWaitForExternalSensorEnabled()
  * @see MPU6050_RA_I2C_MST_CTRL
  */
-void MPU6050::setWaitForExternalSensorEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_WAIT_FOR_ES_BIT, enabled);
+void MPU6050::setWaitForExternalSensorEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_WAIT_FOR_ES_BIT,
+                     enabled);
 }
 /** Get Slave 3 FIFO enabled value.
  * When set to 1, this bit enables EXT_SENS_DATA registers (Registers 73 to 96)
@@ -855,9 +855,9 @@ void MPU6050::setWaitForExternalSensorEnabled(bool enabled)
  * @return Current Slave 3 FIFO enabled value
  * @see MPU6050_RA_MST_CTRL
  */
-bool MPU6050::getSlave3FIFOEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_SLV_3_FIFO_EN_BIT, buffer);
+bool MPU6050::getSlave3FIFOEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_SLV_3_FIFO_EN_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set Slave 3 FIFO enabled value.
@@ -865,9 +865,9 @@ bool MPU6050::getSlave3FIFOEnabled()
  * @see getSlave3FIFOEnabled()
  * @see MPU6050_RA_MST_CTRL
  */
-void MPU6050::setSlave3FIFOEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_SLV_3_FIFO_EN_BIT, enabled);
+void MPU6050::setSlave3FIFOEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_MST_CTRL,
+                     MPU6050_SLV_3_FIFO_EN_BIT, enabled);
 }
 /** Get slave read/write transition enabled value.
  * The I2C_MST_P_NSR bit configures the I2C Master's transition from one slave
@@ -879,9 +879,9 @@ void MPU6050::setSlave3FIFOEnabled(bool enabled)
  * @return Current slave read/write transition enabled value
  * @see MPU6050_RA_I2C_MST_CTRL
  */
-bool MPU6050::getSlaveReadWriteTransitionEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_I2C_MST_P_NSR_BIT, buffer);
+bool MPU6050::getSlaveReadWriteTransitionEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_I2C_MST_P_NSR_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set slave read/write transition enabled value.
@@ -889,9 +889,9 @@ bool MPU6050::getSlaveReadWriteTransitionEnabled()
  * @see getSlaveReadWriteTransitionEnabled()
  * @see MPU6050_RA_I2C_MST_CTRL
  */
-void MPU6050::setSlaveReadWriteTransitionEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_I2C_MST_P_NSR_BIT, enabled);
+void MPU6050::setSlaveReadWriteTransitionEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_MST_CTRL,
+                     MPU6050_I2C_MST_P_NSR_BIT, enabled);
 }
 /** Get I2C master clock speed.
  * I2C_MST_CLK is a 4 bit unsigned value which configures a divider on the
@@ -922,18 +922,18 @@ void MPU6050::setSlaveReadWriteTransitionEnabled(bool enabled)
  * @return Current I2C master clock speed
  * @see MPU6050_RA_I2C_MST_CTRL
  */
-uint8_t MPU6050::getMasterClockSpeed()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_I2C_MST_CLK_BIT, MPU6050_I2C_MST_CLK_LENGTH, buffer);
+uint8_t MPU6050::getMasterClockSpeed() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_I2C_MST_CLK_BIT,
+                     MPU6050_I2C_MST_CLK_LENGTH, buffer);
     return buffer[0];
 }
 /** Set I2C master clock speed.
  * @reparam speed Current I2C master clock speed
  * @see MPU6050_RA_I2C_MST_CTRL
  */
-void MPU6050::setMasterClockSpeed(uint8_t speed)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_I2C_MST_CLK_BIT, MPU6050_I2C_MST_CLK_LENGTH, speed);
+void MPU6050::setMasterClockSpeed(uint8_t speed) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_I2C_MST_CTRL, MPU6050_I2C_MST_CLK_BIT,
+                      MPU6050_I2C_MST_CLK_LENGTH, speed);
 }
 
 // I2C_SLV* registers (Slave 0-3)
@@ -979,10 +979,9 @@ void MPU6050::setMasterClockSpeed(uint8_t speed)
  * @return Current address for specified slave
  * @see MPU6050_RA_I2C_SLV0_ADDR
  */
-uint8_t MPU6050::getSlaveAddress(uint8_t num)
-{
+uint8_t MPU6050::getSlaveAddress(uint8_t num) {
     if (num > 3) return 0;
-    i2Cdev->readByte(devAddr, MPU6050_RA_I2C_SLV0_ADDR + num*3, buffer);
+    i2Cdev->readByte(devAddr, MPU6050_RA_I2C_SLV0_ADDR + num * 3, buffer);
     return buffer[0];
 }
 /** Set the I2C address of the specified slave (0-3).
@@ -991,10 +990,9 @@ uint8_t MPU6050::getSlaveAddress(uint8_t num)
  * @see getSlaveAddress()
  * @see MPU6050_RA_I2C_SLV0_ADDR
  */
-void MPU6050::setSlaveAddress(uint8_t num, uint8_t address)
-{
+void MPU6050::setSlaveAddress(uint8_t num, uint8_t address) {
     if (num > 3) return;
-    i2Cdev->writeByte(devAddr, MPU6050_RA_I2C_SLV0_ADDR + num*3, address);
+    i2Cdev->writeByte(devAddr, MPU6050_RA_I2C_SLV0_ADDR + num * 3, address);
 }
 /** Get the active internal register for the specified slave (0-3).
  * Read/write operations for this slave will be done to whatever internal
@@ -1007,10 +1005,9 @@ void MPU6050::setSlaveAddress(uint8_t num, uint8_t address)
  * @return Current active register for specified slave
  * @see MPU6050_RA_I2C_SLV0_REG
  */
-uint8_t MPU6050::getSlaveRegister(uint8_t num)
-{
+uint8_t MPU6050::getSlaveRegister(uint8_t num) {
     if (num > 3) return 0;
-    i2Cdev->readByte(devAddr, MPU6050_RA_I2C_SLV0_REG + num*3, buffer);
+    i2Cdev->readByte(devAddr, MPU6050_RA_I2C_SLV0_REG + num * 3, buffer);
     return buffer[0];
 }
 /** Set the active internal register for the specified slave (0-3).
@@ -1019,10 +1016,9 @@ uint8_t MPU6050::getSlaveRegister(uint8_t num)
  * @see getSlaveRegister()
  * @see MPU6050_RA_I2C_SLV0_REG
  */
-void MPU6050::setSlaveRegister(uint8_t num, uint8_t reg)
-{
+void MPU6050::setSlaveRegister(uint8_t num, uint8_t reg) {
     if (num > 3) return;
-    i2Cdev->writeByte(devAddr, MPU6050_RA_I2C_SLV0_REG + num*3, reg);
+    i2Cdev->writeByte(devAddr, MPU6050_RA_I2C_SLV0_REG + num * 3, reg);
 }
 /** Get the enabled value for the specified slave (0-3).
  * When set to 1, this bit enables Slave 0 for data transfer operations. When
@@ -1031,22 +1027,22 @@ void MPU6050::setSlaveRegister(uint8_t num, uint8_t reg)
  * @return Current enabled value for specified slave
  * @see MPU6050_RA_I2C_SLV0_CTRL
  */
-bool MPU6050::getSlaveEnabled(uint8_t num)
-{
+bool MPU6050::getSlaveEnabled(uint8_t num) {
     if (num > 3) return 0;
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num*3, MPU6050_I2C_SLV_EN_BIT, buffer);
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num * 3,
+                    MPU6050_I2C_SLV_EN_BIT, buffer);
     return buffer[0];
 }
 /** Set the enabled value for the specified slave (0-3).
  * @param num Slave number (0-3)
- * @param enabled New enabled value for specified slave 
+ * @param enabled New enabled value for specified slave
  * @see getSlaveEnabled()
  * @see MPU6050_RA_I2C_SLV0_CTRL
  */
-void MPU6050::setSlaveEnabled(uint8_t num, bool enabled)
-{
+void MPU6050::setSlaveEnabled(uint8_t num, bool enabled) {
     if (num > 3) return;
-    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num*3, MPU6050_I2C_SLV_EN_BIT, enabled);
+    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num * 3,
+                     MPU6050_I2C_SLV_EN_BIT, enabled);
 }
 /** Get word pair byte-swapping enabled for the specified slave (0-3).
  * When set to 1, this bit enables byte swapping. When byte swapping is enabled,
@@ -1059,10 +1055,10 @@ void MPU6050::setSlaveEnabled(uint8_t num, bool enabled)
  * @return Current word pair byte-swapping enabled value for specified slave
  * @see MPU6050_RA_I2C_SLV0_CTRL
  */
-bool MPU6050::getSlaveWordByteSwap(uint8_t num)
-{
+bool MPU6050::getSlaveWordByteSwap(uint8_t num) {
     if (num > 3) return 0;
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num*3, MPU6050_I2C_SLV_BYTE_SW_BIT, buffer);
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num * 3,
+                    MPU6050_I2C_SLV_BYTE_SW_BIT, buffer);
     return buffer[0];
 }
 /** Set word pair byte-swapping enabled for the specified slave (0-3).
@@ -1071,10 +1067,10 @@ bool MPU6050::getSlaveWordByteSwap(uint8_t num)
  * @see getSlaveWordByteSwap()
  * @see MPU6050_RA_I2C_SLV0_CTRL
  */
-void MPU6050::setSlaveWordByteSwap(uint8_t num, bool enabled)
-{
+void MPU6050::setSlaveWordByteSwap(uint8_t num, bool enabled) {
     if (num > 3) return;
-    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num*3, MPU6050_I2C_SLV_BYTE_SW_BIT, enabled);
+    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num * 3,
+                     MPU6050_I2C_SLV_BYTE_SW_BIT, enabled);
 }
 /** Get write mode for the specified slave (0-3).
  * When set to 1, the transaction will read or write data only. When cleared to
@@ -1083,25 +1079,27 @@ void MPU6050::setSlaveWordByteSwap(uint8_t num, bool enabled)
  * Slave device to/from which the ensuing data transaction will take place.
  *
  * @param num Slave number (0-3)
- * @return Current write mode for specified slave (0 = register address + data, 1 = data only)
+ * @return Current write mode for specified slave (0 = register address + data,
+ *1 = data only)
  * @see MPU6050_RA_I2C_SLV0_CTRL
  */
-bool MPU6050::getSlaveWriteMode(uint8_t num)
-{
+bool MPU6050::getSlaveWriteMode(uint8_t num) {
     if (num > 3) return 0;
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num*3, MPU6050_I2C_SLV_REG_DIS_BIT, buffer);
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num * 3,
+                    MPU6050_I2C_SLV_REG_DIS_BIT, buffer);
     return buffer[0];
 }
 /** Set write mode for the specified slave (0-3).
  * @param num Slave number (0-3)
- * @param mode New write mode for specified slave (0 = register address + data, 1 = data only)
+ * @param mode New write mode for specified slave (0 = register address + data,
+ * 1 = data only)
  * @see getSlaveWriteMode()
  * @see MPU6050_RA_I2C_SLV0_CTRL
  */
-void MPU6050::setSlaveWriteMode(uint8_t num, bool mode)
-{
+void MPU6050::setSlaveWriteMode(uint8_t num, bool mode) {
     if (num > 3) return;
-    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num*3, MPU6050_I2C_SLV_REG_DIS_BIT, mode);
+    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num * 3,
+                     MPU6050_I2C_SLV_REG_DIS_BIT, mode);
 }
 /** Get word pair grouping order offset for the specified slave (0-3).
  * This sets specifies the grouping order of word pairs received from registers.
@@ -1114,10 +1112,10 @@ void MPU6050::setSlaveWriteMode(uint8_t num, bool mode)
  * @return Current word pair grouping order offset for specified slave
  * @see MPU6050_RA_I2C_SLV0_CTRL
  */
-bool MPU6050::getSlaveWordGroupOffset(uint8_t num)
-{
+bool MPU6050::getSlaveWordGroupOffset(uint8_t num) {
     if (num > 3) return 0;
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num*3, MPU6050_I2C_SLV_GRP_BIT, buffer);
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num * 3,
+                    MPU6050_I2C_SLV_GRP_BIT, buffer);
     return buffer[0];
 }
 /** Set word pair grouping order offset for the specified slave (0-3).
@@ -1126,10 +1124,10 @@ bool MPU6050::getSlaveWordGroupOffset(uint8_t num)
  * @see getSlaveWordGroupOffset()
  * @see MPU6050_RA_I2C_SLV0_CTRL
  */
-void MPU6050::setSlaveWordGroupOffset(uint8_t num, bool enabled)
-{
+void MPU6050::setSlaveWordGroupOffset(uint8_t num, bool enabled) {
     if (num > 3) return;
-    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num*3, MPU6050_I2C_SLV_GRP_BIT, enabled);
+    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num * 3,
+                     MPU6050_I2C_SLV_GRP_BIT, enabled);
 }
 /** Get number of bytes to read for the specified slave (0-3).
  * Specifies the number of bytes transferred to and from Slave 0. Clearing this
@@ -1138,10 +1136,11 @@ void MPU6050::setSlaveWordGroupOffset(uint8_t num, bool enabled)
  * @return Number of bytes to read for specified slave
  * @see MPU6050_RA_I2C_SLV0_CTRL
  */
-uint8_t MPU6050::getSlaveDataLength(uint8_t num)
-{
+uint8_t MPU6050::getSlaveDataLength(uint8_t num) {
     if (num > 3) return 0;
-    i2Cdev->readBits(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num*3, MPU6050_I2C_SLV_LEN_BIT, MPU6050_I2C_SLV_LEN_LENGTH, buffer);
+    i2Cdev->readBits(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num * 3,
+                     MPU6050_I2C_SLV_LEN_BIT, MPU6050_I2C_SLV_LEN_LENGTH,
+                     buffer);
     return buffer[0];
 }
 /** Set number of bytes to read for the specified slave (0-3).
@@ -1150,10 +1149,11 @@ uint8_t MPU6050::getSlaveDataLength(uint8_t num)
  * @see getSlaveDataLength()
  * @see MPU6050_RA_I2C_SLV0_CTRL
  */
-void MPU6050::setSlaveDataLength(uint8_t num, uint8_t length)
-{
+void MPU6050::setSlaveDataLength(uint8_t num, uint8_t length) {
     if (num > 3) return;
-    i2Cdev->writeBits(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num*3, MPU6050_I2C_SLV_LEN_BIT, MPU6050_I2C_SLV_LEN_LENGTH, length);
+    i2Cdev->writeBits(devAddr, MPU6050_RA_I2C_SLV0_CTRL + num * 3,
+                      MPU6050_I2C_SLV_LEN_BIT, MPU6050_I2C_SLV_LEN_LENGTH,
+                      length);
 }
 
 // I2C_SLV* registers (Slave 4)
@@ -1167,8 +1167,7 @@ void MPU6050::setSlaveDataLength(uint8_t num, uint8_t length)
  * @see getSlaveAddress()
  * @see MPU6050_RA_I2C_SLV4_ADDR
  */
-uint8_t MPU6050::getSlave4Address()
-{
+uint8_t MPU6050::getSlave4Address() {
     i2Cdev->readByte(devAddr, MPU6050_RA_I2C_SLV4_ADDR, buffer);
     return buffer[0];
 }
@@ -1177,8 +1176,7 @@ uint8_t MPU6050::getSlave4Address()
  * @see getSlave4Address()
  * @see MPU6050_RA_I2C_SLV4_ADDR
  */
-void MPU6050::setSlave4Address(uint8_t address)
-{
+void MPU6050::setSlave4Address(uint8_t address) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_I2C_SLV4_ADDR, address);
 }
 /** Get the active internal register for the Slave 4.
@@ -1188,8 +1186,7 @@ void MPU6050::setSlave4Address(uint8_t address)
  * @return Current active register for Slave 4
  * @see MPU6050_RA_I2C_SLV4_REG
  */
-uint8_t MPU6050::getSlave4Register()
-{
+uint8_t MPU6050::getSlave4Register() {
     i2Cdev->readByte(devAddr, MPU6050_RA_I2C_SLV4_REG, buffer);
     return buffer[0];
 }
@@ -1198,8 +1195,7 @@ uint8_t MPU6050::getSlave4Register()
  * @see getSlave4Register()
  * @see MPU6050_RA_I2C_SLV4_REG
  */
-void MPU6050::setSlave4Register(uint8_t reg)
-{
+void MPU6050::setSlave4Register(uint8_t reg) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_I2C_SLV4_REG, reg);
 }
 /** Set new byte to write to Slave 4.
@@ -1208,8 +1204,7 @@ void MPU6050::setSlave4Register(uint8_t reg)
  * @param data New byte to write to Slave 4
  * @see MPU6050_RA_I2C_SLV4_DO
  */
-void MPU6050::setSlave4OutputByte(uint8_t data)
-{
+void MPU6050::setSlave4OutputByte(uint8_t data) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_I2C_SLV4_DO, data);
 }
 /** Get the enabled value for the Slave 4.
@@ -1218,9 +1213,9 @@ void MPU6050::setSlave4OutputByte(uint8_t data)
  * @return Current enabled value for Slave 4
  * @see MPU6050_RA_I2C_SLV4_CTRL
  */
-bool MPU6050::getSlave4Enabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV4_CTRL, MPU6050_I2C_SLV4_EN_BIT, buffer);
+bool MPU6050::getSlave4Enabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV4_CTRL, MPU6050_I2C_SLV4_EN_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set the enabled value for Slave 4.
@@ -1228,9 +1223,9 @@ bool MPU6050::getSlave4Enabled()
  * @see getSlave4Enabled()
  * @see MPU6050_RA_I2C_SLV4_CTRL
  */
-void MPU6050::setSlave4Enabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV4_CTRL, MPU6050_I2C_SLV4_EN_BIT, enabled);
+void MPU6050::setSlave4Enabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV4_CTRL, MPU6050_I2C_SLV4_EN_BIT,
+                     enabled);
 }
 /** Get the enabled value for Slave 4 transaction interrupts.
  * When set to 1, this bit enables the generation of an interrupt signal upon
@@ -1241,9 +1236,9 @@ void MPU6050::setSlave4Enabled(bool enabled)
  * @return Current enabled value for Slave 4 transaction interrupts.
  * @see MPU6050_RA_I2C_SLV4_CTRL
  */
-bool MPU6050::getSlave4InterruptEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV4_CTRL, MPU6050_I2C_SLV4_INT_EN_BIT, buffer);
+bool MPU6050::getSlave4InterruptEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV4_CTRL,
+                    MPU6050_I2C_SLV4_INT_EN_BIT, buffer);
     return buffer[0];
 }
 /** Set the enabled value for Slave 4 transaction interrupts.
@@ -1251,9 +1246,9 @@ bool MPU6050::getSlave4InterruptEnabled()
  * @see getSlave4InterruptEnabled()
  * @see MPU6050_RA_I2C_SLV4_CTRL
  */
-void MPU6050::setSlave4InterruptEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV4_CTRL, MPU6050_I2C_SLV4_INT_EN_BIT, enabled);
+void MPU6050::setSlave4InterruptEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV4_CTRL,
+                     MPU6050_I2C_SLV4_INT_EN_BIT, enabled);
 }
 /** Get write mode for Slave 4.
  * When set to 1, the transaction will read or write data only. When cleared to
@@ -1261,22 +1256,24 @@ void MPU6050::setSlave4InterruptEnabled(bool enabled)
  * data. This should equal 0 when specifying the register address within the
  * Slave device to/from which the ensuing data transaction will take place.
  *
- * @return Current write mode for Slave 4 (0 = register address + data, 1 = data only)
+ * @return Current write mode for Slave 4 (0 = register address + data, 1 = data
+ *only)
  * @see MPU6050_RA_I2C_SLV4_CTRL
  */
-bool MPU6050::getSlave4WriteMode()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV4_CTRL, MPU6050_I2C_SLV4_REG_DIS_BIT, buffer);
+bool MPU6050::getSlave4WriteMode() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_SLV4_CTRL,
+                    MPU6050_I2C_SLV4_REG_DIS_BIT, buffer);
     return buffer[0];
 }
 /** Set write mode for the Slave 4.
- * @param mode New write mode for Slave 4 (0 = register address + data, 1 = data only)
+ * @param mode New write mode for Slave 4 (0 = register address + data, 1 = data
+ * only)
  * @see getSlave4WriteMode()
  * @see MPU6050_RA_I2C_SLV4_CTRL
  */
-void MPU6050::setSlave4WriteMode(bool mode)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV4_CTRL, MPU6050_I2C_SLV4_REG_DIS_BIT, mode);
+void MPU6050::setSlave4WriteMode(bool mode) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_SLV4_CTRL,
+                     MPU6050_I2C_SLV4_REG_DIS_BIT, mode);
 }
 /** Get Slave 4 master delay value.
  * This configures the reduced access rate of I2C slaves relative to the Sample
@@ -1293,9 +1290,10 @@ void MPU6050::setSlave4WriteMode(bool mode)
  * @return Current Slave 4 master delay value
  * @see MPU6050_RA_I2C_SLV4_CTRL
  */
-uint8_t MPU6050::getSlave4MasterDelay()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_I2C_SLV4_CTRL, MPU6050_I2C_SLV4_MST_DLY_BIT, MPU6050_I2C_SLV4_MST_DLY_LENGTH, buffer);
+uint8_t MPU6050::getSlave4MasterDelay() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_I2C_SLV4_CTRL,
+                     MPU6050_I2C_SLV4_MST_DLY_BIT,
+                     MPU6050_I2C_SLV4_MST_DLY_LENGTH, buffer);
     return buffer[0];
 }
 /** Set Slave 4 master delay value.
@@ -1303,9 +1301,10 @@ uint8_t MPU6050::getSlave4MasterDelay()
  * @see getSlave4MasterDelay()
  * @see MPU6050_RA_I2C_SLV4_CTRL
  */
-void MPU6050::setSlave4MasterDelay(uint8_t delay)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_I2C_SLV4_CTRL, MPU6050_I2C_SLV4_MST_DLY_BIT, MPU6050_I2C_SLV4_MST_DLY_LENGTH, delay);
+void MPU6050::setSlave4MasterDelay(uint8_t delay) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_I2C_SLV4_CTRL,
+                      MPU6050_I2C_SLV4_MST_DLY_BIT,
+                      MPU6050_I2C_SLV4_MST_DLY_LENGTH, delay);
 }
 /** Get last available byte read from Slave 4.
  * This register stores the data read from Slave 4. This field is populated
@@ -1313,8 +1312,7 @@ void MPU6050::setSlave4MasterDelay(uint8_t delay)
  * @return Last available byte read from to Slave 4
  * @see MPU6050_RA_I2C_SLV4_DI
  */
-uint8_t MPU6050::getSlate4InputByte()
-{
+uint8_t MPU6050::getSlate4InputByte() {
     i2Cdev->readByte(devAddr, MPU6050_RA_I2C_SLV4_DI, buffer);
     return buffer[0];
 }
@@ -1330,9 +1328,9 @@ uint8_t MPU6050::getSlate4InputByte()
  * @return FSYNC interrupt status
  * @see MPU6050_RA_I2C_MST_STATUS
  */
-bool MPU6050::getPassthroughStatus()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS, MPU6050_MST_PASS_THROUGH_BIT, buffer);
+bool MPU6050::getPassthroughStatus() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS,
+                    MPU6050_MST_PASS_THROUGH_BIT, buffer);
     return buffer[0];
 }
 /** Get Slave 4 transaction done status.
@@ -1343,9 +1341,9 @@ bool MPU6050::getPassthroughStatus()
  * @return Slave 4 transaction done status
  * @see MPU6050_RA_I2C_MST_STATUS
  */
-bool MPU6050::getSlave4IsDone()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS, MPU6050_MST_I2C_SLV4_DONE_BIT, buffer);
+bool MPU6050::getSlave4IsDone() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS,
+                    MPU6050_MST_I2C_SLV4_DONE_BIT, buffer);
     return buffer[0];
 }
 /** Get master arbitration lost status.
@@ -1355,9 +1353,9 @@ bool MPU6050::getSlave4IsDone()
  * @return Master arbitration lost status
  * @see MPU6050_RA_I2C_MST_STATUS
  */
-bool MPU6050::getLostArbitration()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS, MPU6050_MST_I2C_LOST_ARB_BIT, buffer);
+bool MPU6050::getLostArbitration() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS,
+                    MPU6050_MST_I2C_LOST_ARB_BIT, buffer);
     return buffer[0];
 }
 /** Get Slave 4 NACK status.
@@ -1367,9 +1365,9 @@ bool MPU6050::getLostArbitration()
  * @return Slave 4 NACK interrupt status
  * @see MPU6050_RA_I2C_MST_STATUS
  */
-bool MPU6050::getSlave4Nack()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS, MPU6050_MST_I2C_SLV4_NACK_BIT, buffer);
+bool MPU6050::getSlave4Nack() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS,
+                    MPU6050_MST_I2C_SLV4_NACK_BIT, buffer);
     return buffer[0];
 }
 /** Get Slave 3 NACK status.
@@ -1379,9 +1377,9 @@ bool MPU6050::getSlave4Nack()
  * @return Slave 3 NACK interrupt status
  * @see MPU6050_RA_I2C_MST_STATUS
  */
-bool MPU6050::getSlave3Nack()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS, MPU6050_MST_I2C_SLV3_NACK_BIT, buffer);
+bool MPU6050::getSlave3Nack() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS,
+                    MPU6050_MST_I2C_SLV3_NACK_BIT, buffer);
     return buffer[0];
 }
 /** Get Slave 2 NACK status.
@@ -1391,9 +1389,9 @@ bool MPU6050::getSlave3Nack()
  * @return Slave 2 NACK interrupt status
  * @see MPU6050_RA_I2C_MST_STATUS
  */
-bool MPU6050::getSlave2Nack()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS, MPU6050_MST_I2C_SLV2_NACK_BIT, buffer);
+bool MPU6050::getSlave2Nack() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS,
+                    MPU6050_MST_I2C_SLV2_NACK_BIT, buffer);
     return buffer[0];
 }
 /** Get Slave 1 NACK status.
@@ -1403,9 +1401,9 @@ bool MPU6050::getSlave2Nack()
  * @return Slave 1 NACK interrupt status
  * @see MPU6050_RA_I2C_MST_STATUS
  */
-bool MPU6050::getSlave1Nack()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS, MPU6050_MST_I2C_SLV1_NACK_BIT, buffer);
+bool MPU6050::getSlave1Nack() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS,
+                    MPU6050_MST_I2C_SLV1_NACK_BIT, buffer);
     return buffer[0];
 }
 /** Get Slave 0 NACK status.
@@ -1415,9 +1413,9 @@ bool MPU6050::getSlave1Nack()
  * @return Slave 0 NACK interrupt status
  * @see MPU6050_RA_I2C_MST_STATUS
  */
-bool MPU6050::getSlave0Nack()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS, MPU6050_MST_I2C_SLV0_NACK_BIT, buffer);
+bool MPU6050::getSlave0Nack() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_STATUS,
+                    MPU6050_MST_I2C_SLV0_NACK_BIT, buffer);
     return buffer[0];
 }
 
@@ -1429,9 +1427,9 @@ bool MPU6050::getSlave0Nack()
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_INT_LEVEL_BIT
  */
-bool MPU6050::getInterruptMode()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_INT_LEVEL_BIT, buffer);
+bool MPU6050::getInterruptMode() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                    MPU6050_INTCFG_INT_LEVEL_BIT, buffer);
     return buffer[0];
 }
 /** Set interrupt logic level mode.
@@ -1440,9 +1438,9 @@ bool MPU6050::getInterruptMode()
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_INT_LEVEL_BIT
  */
-void MPU6050::setInterruptMode(bool mode)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_INT_LEVEL_BIT, mode);
+void MPU6050::setInterruptMode(bool mode) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                     MPU6050_INTCFG_INT_LEVEL_BIT, mode);
 }
 /** Get interrupt drive mode.
  * Will be set 0 for push-pull, 1 for open-drain.
@@ -1450,9 +1448,9 @@ void MPU6050::setInterruptMode(bool mode)
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_INT_OPEN_BIT
  */
-bool MPU6050::getInterruptDrive()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_INT_OPEN_BIT, buffer);
+bool MPU6050::getInterruptDrive() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                    MPU6050_INTCFG_INT_OPEN_BIT, buffer);
     return buffer[0];
 }
 /** Set interrupt drive mode.
@@ -1461,9 +1459,9 @@ bool MPU6050::getInterruptDrive()
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_INT_OPEN_BIT
  */
-void MPU6050::setInterruptDrive(bool drive)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_INT_OPEN_BIT, drive);
+void MPU6050::setInterruptDrive(bool drive) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                     MPU6050_INTCFG_INT_OPEN_BIT, drive);
 }
 /** Get interrupt latch mode.
  * Will be set 0 for 50us-pulse, 1 for latch-until-int-cleared.
@@ -1471,9 +1469,9 @@ void MPU6050::setInterruptDrive(bool drive)
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_LATCH_INT_EN_BIT
  */
-bool MPU6050::getInterruptLatch()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_LATCH_INT_EN_BIT, buffer);
+bool MPU6050::getInterruptLatch() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                    MPU6050_INTCFG_LATCH_INT_EN_BIT, buffer);
     return buffer[0];
 }
 /** Set interrupt latch mode.
@@ -1482,9 +1480,9 @@ bool MPU6050::getInterruptLatch()
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_LATCH_INT_EN_BIT
  */
-void MPU6050::setInterruptLatch(bool latch)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_LATCH_INT_EN_BIT, latch);
+void MPU6050::setInterruptLatch(bool latch) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                     MPU6050_INTCFG_LATCH_INT_EN_BIT, latch);
 }
 /** Get interrupt latch clear mode.
  * Will be set 0 for status-read-only, 1 for any-register-read.
@@ -1492,9 +1490,9 @@ void MPU6050::setInterruptLatch(bool latch)
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_INT_RD_CLEAR_BIT
  */
-bool MPU6050::getInterruptLatchClear()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_INT_RD_CLEAR_BIT, buffer);
+bool MPU6050::getInterruptLatchClear() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                    MPU6050_INTCFG_INT_RD_CLEAR_BIT, buffer);
     return buffer[0];
 }
 /** Set interrupt latch clear mode.
@@ -1503,9 +1501,9 @@ bool MPU6050::getInterruptLatchClear()
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_INT_RD_CLEAR_BIT
  */
-void MPU6050::setInterruptLatchClear(bool clear)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_INT_RD_CLEAR_BIT, clear);
+void MPU6050::setInterruptLatchClear(bool clear) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                     MPU6050_INTCFG_INT_RD_CLEAR_BIT, clear);
 }
 /** Get FSYNC interrupt logic level mode.
  * @return Current FSYNC interrupt mode (0=active-high, 1=active-low)
@@ -1513,9 +1511,9 @@ void MPU6050::setInterruptLatchClear(bool clear)
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_FSYNC_INT_LEVEL_BIT
  */
-bool MPU6050::getFSyncInterruptLevel()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_FSYNC_INT_LEVEL_BIT, buffer);
+bool MPU6050::getFSyncInterruptLevel() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                    MPU6050_INTCFG_FSYNC_INT_LEVEL_BIT, buffer);
     return buffer[0];
 }
 /** Set FSYNC interrupt logic level mode.
@@ -1524,9 +1522,9 @@ bool MPU6050::getFSyncInterruptLevel()
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_FSYNC_INT_LEVEL_BIT
  */
-void MPU6050::setFSyncInterruptLevel(bool level)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_FSYNC_INT_LEVEL_BIT, level);
+void MPU6050::setFSyncInterruptLevel(bool level) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                     MPU6050_INTCFG_FSYNC_INT_LEVEL_BIT, level);
 }
 /** Get FSYNC pin interrupt enabled setting.
  * Will be set 0 for disabled, 1 for enabled.
@@ -1534,9 +1532,9 @@ void MPU6050::setFSyncInterruptLevel(bool level)
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_FSYNC_INT_EN_BIT
  */
-bool MPU6050::getFSyncInterruptEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_FSYNC_INT_EN_BIT, buffer);
+bool MPU6050::getFSyncInterruptEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                    MPU6050_INTCFG_FSYNC_INT_EN_BIT, buffer);
     return buffer[0];
 }
 /** Set FSYNC pin interrupt enabled setting.
@@ -1545,9 +1543,9 @@ bool MPU6050::getFSyncInterruptEnabled()
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_FSYNC_INT_EN_BIT
  */
-void MPU6050::setFSyncInterruptEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_FSYNC_INT_EN_BIT, enabled);
+void MPU6050::setFSyncInterruptEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                     MPU6050_INTCFG_FSYNC_INT_EN_BIT, enabled);
 }
 /** Get I2C bypass enabled status.
  * When this bit is equal to 1 and I2C_MST_EN (Register 106 bit[5]) is equal to
@@ -1560,9 +1558,9 @@ void MPU6050::setFSyncInterruptEnabled(bool enabled)
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_I2C_BYPASS_EN_BIT
  */
-bool MPU6050::getI2CBypassEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_I2C_BYPASS_EN_BIT, buffer);
+bool MPU6050::getI2CBypassEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                    MPU6050_INTCFG_I2C_BYPASS_EN_BIT, buffer);
     return buffer[0];
 }
 /** Set I2C bypass enabled status.
@@ -1576,9 +1574,9 @@ bool MPU6050::getI2CBypassEnabled()
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_I2C_BYPASS_EN_BIT
  */
-void MPU6050::setI2CBypassEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_I2C_BYPASS_EN_BIT, enabled);
+void MPU6050::setI2CBypassEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                     MPU6050_INTCFG_I2C_BYPASS_EN_BIT, enabled);
 }
 /** Get reference clock output enabled status.
  * When this bit is equal to 1, a reference clock output is provided at the
@@ -1589,9 +1587,9 @@ void MPU6050::setI2CBypassEnabled(bool enabled)
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_CLKOUT_EN_BIT
  */
-bool MPU6050::getClockOutputEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_CLKOUT_EN_BIT, buffer);
+bool MPU6050::getClockOutputEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                    MPU6050_INTCFG_CLKOUT_EN_BIT, buffer);
     return buffer[0];
 }
 /** Set reference clock output enabled status.
@@ -1603,9 +1601,9 @@ bool MPU6050::getClockOutputEnabled()
  * @see MPU6050_RA_INT_PIN_CFG
  * @see MPU6050_INTCFG_CLKOUT_EN_BIT
  */
-void MPU6050::setClockOutputEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG, MPU6050_INTCFG_CLKOUT_EN_BIT, enabled);
+void MPU6050::setClockOutputEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_PIN_CFG,
+                     MPU6050_INTCFG_CLKOUT_EN_BIT, enabled);
 }
 
 // INT_ENABLE register
@@ -1617,8 +1615,7 @@ void MPU6050::setClockOutputEnabled(bool enabled)
  * @see MPU6050_RA_INT_ENABLE
  * @see MPU6050_INTERRUPT_FF_BIT
  **/
-uint8_t MPU6050::getIntEnabled()
-{
+uint8_t MPU6050::getIntEnabled() {
     i2Cdev->readByte(devAddr, MPU6050_RA_INT_ENABLE, buffer);
     return buffer[0];
 }
@@ -1630,8 +1627,7 @@ uint8_t MPU6050::getIntEnabled()
  * @see MPU6050_RA_INT_ENABLE
  * @see MPU6050_INTERRUPT_FF_BIT
  **/
-void MPU6050::setIntEnabled(uint8_t enabled)
-{
+void MPU6050::setIntEnabled(uint8_t enabled) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_INT_ENABLE, enabled);
 }
 /** Get Free Fall interrupt enabled status.
@@ -1640,9 +1636,9 @@ void MPU6050::setIntEnabled(uint8_t enabled)
  * @see MPU6050_RA_INT_ENABLE
  * @see MPU6050_INTERRUPT_FF_BIT
  **/
-bool MPU6050::getIntFreefallEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_FF_BIT, buffer);
+bool MPU6050::getIntFreefallEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_FF_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set Free Fall interrupt enabled status.
@@ -1651,9 +1647,9 @@ bool MPU6050::getIntFreefallEnabled()
  * @see MPU6050_RA_INT_ENABLE
  * @see MPU6050_INTERRUPT_FF_BIT
  **/
-void MPU6050::setIntFreefallEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_FF_BIT, enabled);
+void MPU6050::setIntFreefallEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_FF_BIT,
+                     enabled);
 }
 /** Get Motion Detection interrupt enabled status.
  * Will be set 0 for disabled, 1 for enabled.
@@ -1661,9 +1657,9 @@ void MPU6050::setIntFreefallEnabled(bool enabled)
  * @see MPU6050_RA_INT_ENABLE
  * @see MPU6050_INTERRUPT_MOT_BIT
  **/
-bool MPU6050::getIntMotionEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_MOT_BIT, buffer);
+bool MPU6050::getIntMotionEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_MOT_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set Motion Detection interrupt enabled status.
@@ -1672,9 +1668,9 @@ bool MPU6050::getIntMotionEnabled()
  * @see MPU6050_RA_INT_ENABLE
  * @see MPU6050_INTERRUPT_MOT_BIT
  **/
-void MPU6050::setIntMotionEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_MOT_BIT, enabled);
+void MPU6050::setIntMotionEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_MOT_BIT,
+                     enabled);
 }
 /** Get Zero Motion Detection interrupt enabled status.
  * Will be set 0 for disabled, 1 for enabled.
@@ -1682,9 +1678,9 @@ void MPU6050::setIntMotionEnabled(bool enabled)
  * @see MPU6050_RA_INT_ENABLE
  * @see MPU6050_INTERRUPT_ZMOT_BIT
  **/
-bool MPU6050::getIntZeroMotionEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_ZMOT_BIT, buffer);
+bool MPU6050::getIntZeroMotionEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_ZMOT_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set Zero Motion Detection interrupt enabled status.
@@ -1693,9 +1689,9 @@ bool MPU6050::getIntZeroMotionEnabled()
  * @see MPU6050_RA_INT_ENABLE
  * @see MPU6050_INTERRUPT_ZMOT_BIT
  **/
-void MPU6050::setIntZeroMotionEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_ZMOT_BIT, enabled);
+void MPU6050::setIntZeroMotionEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_ZMOT_BIT,
+                     enabled);
 }
 /** Get FIFO Buffer Overflow interrupt enabled status.
  * Will be set 0 for disabled, 1 for enabled.
@@ -1703,9 +1699,9 @@ void MPU6050::setIntZeroMotionEnabled(bool enabled)
  * @see MPU6050_RA_INT_ENABLE
  * @see MPU6050_INTERRUPT_FIFO_OFLOW_BIT
  **/
-bool MPU6050::getIntFIFOBufferOverflowEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_FIFO_OFLOW_BIT, buffer);
+bool MPU6050::getIntFIFOBufferOverflowEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE,
+                    MPU6050_INTERRUPT_FIFO_OFLOW_BIT, buffer);
     return buffer[0];
 }
 /** Set FIFO Buffer Overflow interrupt enabled status.
@@ -1714,9 +1710,9 @@ bool MPU6050::getIntFIFOBufferOverflowEnabled()
  * @see MPU6050_RA_INT_ENABLE
  * @see MPU6050_INTERRUPT_FIFO_OFLOW_BIT
  **/
-void MPU6050::setIntFIFOBufferOverflowEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_FIFO_OFLOW_BIT, enabled);
+void MPU6050::setIntFIFOBufferOverflowEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE,
+                     MPU6050_INTERRUPT_FIFO_OFLOW_BIT, enabled);
 }
 /** Get I2C Master interrupt enabled status.
  * This enables any of the I2C Master interrupt sources to generate an
@@ -1725,9 +1721,9 @@ void MPU6050::setIntFIFOBufferOverflowEnabled(bool enabled)
  * @see MPU6050_RA_INT_ENABLE
  * @see MPU6050_INTERRUPT_I2C_MST_INT_BIT
  **/
-bool MPU6050::getIntI2CMasterEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_I2C_MST_INT_BIT, buffer);
+bool MPU6050::getIntI2CMasterEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE,
+                    MPU6050_INTERRUPT_I2C_MST_INT_BIT, buffer);
     return buffer[0];
 }
 /** Set I2C Master interrupt enabled status.
@@ -1736,9 +1732,9 @@ bool MPU6050::getIntI2CMasterEnabled()
  * @see MPU6050_RA_INT_ENABLE
  * @see MPU6050_INTERRUPT_I2C_MST_INT_BIT
  **/
-void MPU6050::setIntI2CMasterEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_I2C_MST_INT_BIT, enabled);
+void MPU6050::setIntI2CMasterEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE,
+                     MPU6050_INTERRUPT_I2C_MST_INT_BIT, enabled);
 }
 /** Get Data Ready interrupt enabled setting.
  * This event occurs each time a write operation to all of the sensor registers
@@ -1747,9 +1743,9 @@ void MPU6050::setIntI2CMasterEnabled(bool enabled)
  * @see MPU6050_RA_INT_ENABLE
  * @see MPU6050_INTERRUPT_DATA_RDY_BIT
  */
-bool MPU6050::getIntDataReadyEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_DATA_RDY_BIT, buffer);
+bool MPU6050::getIntDataReadyEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE,
+                    MPU6050_INTERRUPT_DATA_RDY_BIT, buffer);
     return buffer[0];
 }
 /** Set Data Ready interrupt enabled status.
@@ -1758,9 +1754,9 @@ bool MPU6050::getIntDataReadyEnabled()
  * @see MPU6050_RA_INT_CFG
  * @see MPU6050_INTERRUPT_DATA_RDY_BIT
  */
-void MPU6050::setIntDataReadyEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_DATA_RDY_BIT, enabled);
+void MPU6050::setIntDataReadyEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE,
+                     MPU6050_INTERRUPT_DATA_RDY_BIT, enabled);
 }
 
 // INT_STATUS register
@@ -1772,8 +1768,7 @@ void MPU6050::setIntDataReadyEnabled(bool enabled)
  * @return Current interrupt status
  * @see MPU6050_RA_INT_STATUS
  */
-uint8_t MPU6050::getIntStatus()
-{
+uint8_t MPU6050::getIntStatus() {
     i2Cdev->readByte(devAddr, MPU6050_RA_INT_STATUS, buffer);
     return buffer[0];
 }
@@ -1784,9 +1779,9 @@ uint8_t MPU6050::getIntStatus()
  * @see MPU6050_RA_INT_STATUS
  * @see MPU6050_INTERRUPT_FF_BIT
  */
-bool MPU6050::getIntFreefallStatus()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS, MPU6050_INTERRUPT_FF_BIT, buffer);
+bool MPU6050::getIntFreefallStatus() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS, MPU6050_INTERRUPT_FF_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Get Motion Detection interrupt status.
@@ -1796,9 +1791,9 @@ bool MPU6050::getIntFreefallStatus()
  * @see MPU6050_RA_INT_STATUS
  * @see MPU6050_INTERRUPT_MOT_BIT
  */
-bool MPU6050::getIntMotionStatus()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS, MPU6050_INTERRUPT_MOT_BIT, buffer);
+bool MPU6050::getIntMotionStatus() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS, MPU6050_INTERRUPT_MOT_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Get Zero Motion Detection interrupt status.
@@ -1808,9 +1803,9 @@ bool MPU6050::getIntMotionStatus()
  * @see MPU6050_RA_INT_STATUS
  * @see MPU6050_INTERRUPT_ZMOT_BIT
  */
-bool MPU6050::getIntZeroMotionStatus()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS, MPU6050_INTERRUPT_ZMOT_BIT, buffer);
+bool MPU6050::getIntZeroMotionStatus() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS, MPU6050_INTERRUPT_ZMOT_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Get FIFO Buffer Overflow interrupt status.
@@ -1820,9 +1815,9 @@ bool MPU6050::getIntZeroMotionStatus()
  * @see MPU6050_RA_INT_STATUS
  * @see MPU6050_INTERRUPT_FIFO_OFLOW_BIT
  */
-bool MPU6050::getIntFIFOBufferOverflowStatus()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS, MPU6050_INTERRUPT_FIFO_OFLOW_BIT, buffer);
+bool MPU6050::getIntFIFOBufferOverflowStatus() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS,
+                    MPU6050_INTERRUPT_FIFO_OFLOW_BIT, buffer);
     return buffer[0];
 }
 /** Get I2C Master interrupt status.
@@ -1833,9 +1828,9 @@ bool MPU6050::getIntFIFOBufferOverflowStatus()
  * @see MPU6050_RA_INT_STATUS
  * @see MPU6050_INTERRUPT_I2C_MST_INT_BIT
  */
-bool MPU6050::getIntI2CMasterStatus()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS, MPU6050_INTERRUPT_I2C_MST_INT_BIT, buffer);
+bool MPU6050::getIntI2CMasterStatus() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS,
+                    MPU6050_INTERRUPT_I2C_MST_INT_BIT, buffer);
     return buffer[0];
 }
 /** Get Data Ready interrupt status.
@@ -1845,9 +1840,9 @@ bool MPU6050::getIntI2CMasterStatus()
  * @see MPU6050_RA_INT_STATUS
  * @see MPU6050_INTERRUPT_DATA_RDY_BIT
  */
-bool MPU6050::getIntDataReadyStatus()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS, MPU6050_INTERRUPT_DATA_RDY_BIT, buffer);
+bool MPU6050::getIntDataReadyStatus() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS,
+                    MPU6050_INTERRUPT_DATA_RDY_BIT, buffer);
     return buffer[0];
 }
 
@@ -1869,8 +1864,9 @@ bool MPU6050::getIntDataReadyStatus()
  * @see getRotation()
  * @see MPU6050_RA_ACCEL_XOUT_H
  */
-void MPU6050::getMotion9(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx, int16_t* gy, int16_t* gz, int16_t* mx, int16_t* my, int16_t* mz)
-{
+void MPU6050::getMotion9(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx,
+                         int16_t* gy, int16_t* gz, int16_t* mx, int16_t* my,
+                         int16_t* mz) {
     getMotion6(ax, ay, az, gx, gy, gz);
     // TODO: magnetometer integration
 }
@@ -1886,8 +1882,8 @@ void MPU6050::getMotion9(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx, int
  * @see getRotation()
  * @see MPU6050_RA_ACCEL_XOUT_H
  */
-void MPU6050::getMotion6(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx, int16_t* gy, int16_t* gz)
-{
+void MPU6050::getMotion6(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx,
+                         int16_t* gy, int16_t* gz) {
     i2Cdev->readBytes(devAddr, MPU6050_RA_ACCEL_XOUT_H, 14, buffer);
     *ax = (((int16_t)buffer[0]) << 8) | buffer[1];
     *ay = (((int16_t)buffer[2]) << 8) | buffer[3];
@@ -1932,8 +1928,7 @@ void MPU6050::getMotion6(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx, int
  * @param z 16-bit signed integer container for Z-axis acceleration
  * @see MPU6050_RA_GYRO_XOUT_H
  */
-void MPU6050::getAcceleration(int16_t* x, int16_t* y, int16_t* z)
-{
+void MPU6050::getAcceleration(int16_t* x, int16_t* y, int16_t* z) {
     i2Cdev->readBytes(devAddr, MPU6050_RA_ACCEL_XOUT_H, 6, buffer);
     *x = (((int16_t)buffer[0]) << 8) | buffer[1];
     *y = (((int16_t)buffer[2]) << 8) | buffer[3];
@@ -1944,8 +1939,7 @@ void MPU6050::getAcceleration(int16_t* x, int16_t* y, int16_t* z)
  * @see getMotion6()
  * @see MPU6050_RA_ACCEL_XOUT_H
  */
-int16_t MPU6050::getAccelerationX()
-{
+int16_t MPU6050::getAccelerationX() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_ACCEL_XOUT_H, 2, buffer);
     return (((int16_t)buffer[0]) << 8) | buffer[1];
 }
@@ -1954,8 +1948,7 @@ int16_t MPU6050::getAccelerationX()
  * @see getMotion6()
  * @see MPU6050_RA_ACCEL_YOUT_H
  */
-int16_t MPU6050::getAccelerationY()
-{
+int16_t MPU6050::getAccelerationY() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_ACCEL_YOUT_H, 2, buffer);
     return (((int16_t)buffer[0]) << 8) | buffer[1];
 }
@@ -1964,8 +1957,7 @@ int16_t MPU6050::getAccelerationY()
  * @see getMotion6()
  * @see MPU6050_RA_ACCEL_ZOUT_H
  */
-int16_t MPU6050::getAccelerationZ()
-{
+int16_t MPU6050::getAccelerationZ() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_ACCEL_ZOUT_H, 2, buffer);
     return (((int16_t)buffer[0]) << 8) | buffer[1];
 }
@@ -1976,8 +1968,7 @@ int16_t MPU6050::getAccelerationZ()
  * @return Temperature reading in 16-bit 2's complement format
  * @see MPU6050_RA_TEMP_OUT_H
  */
-int16_t MPU6050::getTemperature()
-{
+int16_t MPU6050::getTemperature() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_TEMP_OUT_H, 2, buffer);
     return (((int16_t)buffer[0]) << 8) | buffer[1];
 }
@@ -2016,8 +2007,7 @@ int16_t MPU6050::getTemperature()
  * @see getMotion6()
  * @see MPU6050_RA_GYRO_XOUT_H
  */
-void MPU6050::getRotation(int16_t* x, int16_t* y, int16_t* z)
-{
+void MPU6050::getRotation(int16_t* x, int16_t* y, int16_t* z) {
     i2Cdev->readBytes(devAddr, MPU6050_RA_GYRO_XOUT_H, 6, buffer);
     *x = (((int16_t)buffer[0]) << 8) | buffer[1];
     *y = (((int16_t)buffer[2]) << 8) | buffer[3];
@@ -2028,8 +2018,7 @@ void MPU6050::getRotation(int16_t* x, int16_t* y, int16_t* z)
  * @see getMotion6()
  * @see MPU6050_RA_GYRO_XOUT_H
  */
-int16_t MPU6050::getRotationX()
-{
+int16_t MPU6050::getRotationX() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_GYRO_XOUT_H, 2, buffer);
     return (((int16_t)buffer[0]) << 8) | buffer[1];
 }
@@ -2038,8 +2027,7 @@ int16_t MPU6050::getRotationX()
  * @see getMotion6()
  * @see MPU6050_RA_GYRO_YOUT_H
  */
-int16_t MPU6050::getRotationY()
-{
+int16_t MPU6050::getRotationY() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_GYRO_YOUT_H, 2, buffer);
     return (((int16_t)buffer[0]) << 8) | buffer[1];
 }
@@ -2048,8 +2036,7 @@ int16_t MPU6050::getRotationY()
  * @see getMotion6()
  * @see MPU6050_RA_GYRO_ZOUT_H
  */
-int16_t MPU6050::getRotationZ()
-{
+int16_t MPU6050::getRotationZ() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_GYRO_ZOUT_H, 2, buffer);
     return (((int16_t)buffer[0]) << 8) | buffer[1];
 }
@@ -2130,8 +2117,7 @@ int16_t MPU6050::getRotationZ()
  * @param position Starting position (0-23)
  * @return Byte read from register
  */
-uint8_t MPU6050::getExternalSensorByte(int position)
-{
+uint8_t MPU6050::getExternalSensorByte(int position) {
     i2Cdev->readByte(devAddr, MPU6050_RA_EXT_SENS_DATA_00 + position, buffer);
     return buffer[0];
 }
@@ -2140,9 +2126,9 @@ uint8_t MPU6050::getExternalSensorByte(int position)
  * @return Word read from register
  * @see getExternalSensorByte()
  */
-uint16_t MPU6050::getExternalSensorWord(int position)
-{
-    i2Cdev->readBytes(devAddr, MPU6050_RA_EXT_SENS_DATA_00 + position, 2, buffer);
+uint16_t MPU6050::getExternalSensorWord(int position) {
+    i2Cdev->readBytes(devAddr, MPU6050_RA_EXT_SENS_DATA_00 + position, 2,
+                      buffer);
     return (((uint16_t)buffer[0]) << 8) | buffer[1];
 }
 /** Read double word (4 bytes) from external sensor data registers.
@@ -2150,10 +2136,11 @@ uint16_t MPU6050::getExternalSensorWord(int position)
  * @return Double word read from registers
  * @see getExternalSensorByte()
  */
-uint32_t MPU6050::getExternalSensorDWord(int position)
-{
-    i2Cdev->readBytes(devAddr, MPU6050_RA_EXT_SENS_DATA_00 + position, 4, buffer);
-    return (((uint32_t)buffer[0]) << 24) | (((uint32_t)buffer[1]) << 16) | (((uint16_t)buffer[2]) << 8) | buffer[3];
+uint32_t MPU6050::getExternalSensorDWord(int position) {
+    i2Cdev->readBytes(devAddr, MPU6050_RA_EXT_SENS_DATA_00 + position, 4,
+                      buffer);
+    return (((uint32_t)buffer[0]) << 24) | (((uint32_t)buffer[1]) << 16) |
+           (((uint16_t)buffer[2]) << 8) | buffer[3];
 }
 
 // MOT_DETECT_STATUS register
@@ -2163,9 +2150,9 @@ uint32_t MPU6050::getExternalSensorDWord(int position)
  * @see MPU6050_RA_MOT_DETECT_STATUS
  * @see MPU6050_MOTION_MOT_XNEG_BIT
  */
-bool MPU6050::getXNegMotionDetected()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS, MPU6050_MOTION_MOT_XNEG_BIT, buffer);
+bool MPU6050::getXNegMotionDetected() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS,
+                    MPU6050_MOTION_MOT_XNEG_BIT, buffer);
     return buffer[0];
 }
 /** Get X-axis positive motion detection interrupt status.
@@ -2173,9 +2160,9 @@ bool MPU6050::getXNegMotionDetected()
  * @see MPU6050_RA_MOT_DETECT_STATUS
  * @see MPU6050_MOTION_MOT_XPOS_BIT
  */
-bool MPU6050::getXPosMotionDetected()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS, MPU6050_MOTION_MOT_XPOS_BIT, buffer);
+bool MPU6050::getXPosMotionDetected() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS,
+                    MPU6050_MOTION_MOT_XPOS_BIT, buffer);
     return buffer[0];
 }
 /** Get Y-axis negative motion detection interrupt status.
@@ -2183,9 +2170,9 @@ bool MPU6050::getXPosMotionDetected()
  * @see MPU6050_RA_MOT_DETECT_STATUS
  * @see MPU6050_MOTION_MOT_YNEG_BIT
  */
-bool MPU6050::getYNegMotionDetected()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS, MPU6050_MOTION_MOT_YNEG_BIT, buffer);
+bool MPU6050::getYNegMotionDetected() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS,
+                    MPU6050_MOTION_MOT_YNEG_BIT, buffer);
     return buffer[0];
 }
 /** Get Y-axis positive motion detection interrupt status.
@@ -2193,9 +2180,9 @@ bool MPU6050::getYNegMotionDetected()
  * @see MPU6050_RA_MOT_DETECT_STATUS
  * @see MPU6050_MOTION_MOT_YPOS_BIT
  */
-bool MPU6050::getYPosMotionDetected()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS, MPU6050_MOTION_MOT_YPOS_BIT, buffer);
+bool MPU6050::getYPosMotionDetected() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS,
+                    MPU6050_MOTION_MOT_YPOS_BIT, buffer);
     return buffer[0];
 }
 /** Get Z-axis negative motion detection interrupt status.
@@ -2203,9 +2190,9 @@ bool MPU6050::getYPosMotionDetected()
  * @see MPU6050_RA_MOT_DETECT_STATUS
  * @see MPU6050_MOTION_MOT_ZNEG_BIT
  */
-bool MPU6050::getZNegMotionDetected()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS, MPU6050_MOTION_MOT_ZNEG_BIT, buffer);
+bool MPU6050::getZNegMotionDetected() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS,
+                    MPU6050_MOTION_MOT_ZNEG_BIT, buffer);
     return buffer[0];
 }
 /** Get Z-axis positive motion detection interrupt status.
@@ -2213,9 +2200,9 @@ bool MPU6050::getZNegMotionDetected()
  * @see MPU6050_RA_MOT_DETECT_STATUS
  * @see MPU6050_MOTION_MOT_ZPOS_BIT
  */
-bool MPU6050::getZPosMotionDetected()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS, MPU6050_MOTION_MOT_ZPOS_BIT, buffer);
+bool MPU6050::getZPosMotionDetected() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS,
+                    MPU6050_MOTION_MOT_ZPOS_BIT, buffer);
     return buffer[0];
 }
 /** Get zero motion detection interrupt status.
@@ -2223,9 +2210,9 @@ bool MPU6050::getZPosMotionDetected()
  * @see MPU6050_RA_MOT_DETECT_STATUS
  * @see MPU6050_MOTION_MOT_ZRMOT_BIT
  */
-bool MPU6050::getZeroMotionDetected()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS, MPU6050_MOTION_MOT_ZRMOT_BIT, buffer);
+bool MPU6050::getZeroMotionDetected() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_MOT_DETECT_STATUS,
+                    MPU6050_MOTION_MOT_ZRMOT_BIT, buffer);
     return buffer[0];
 }
 
@@ -2239,8 +2226,7 @@ bool MPU6050::getZeroMotionDetected()
  * @param data Byte to write
  * @see MPU6050_RA_I2C_SLV0_DO
  */
-void MPU6050::setSlaveOutputByte(uint8_t num, uint8_t data)
-{
+void MPU6050::setSlaveOutputByte(uint8_t num, uint8_t data) {
     if (num > 3) return;
     i2Cdev->writeByte(devAddr, MPU6050_RA_I2C_SLV0_DO + num, data);
 }
@@ -2255,9 +2241,9 @@ void MPU6050::setSlaveOutputByte(uint8_t num, uint8_t data)
  * @see MPU6050_RA_I2C_MST_DELAY_CTRL
  * @see MPU6050_DELAYCTRL_DELAY_ES_SHADOW_BIT
  */
-bool MPU6050::getExternalShadowDelayEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_DELAY_CTRL, MPU6050_DELAYCTRL_DELAY_ES_SHADOW_BIT, buffer);
+bool MPU6050::getExternalShadowDelayEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_DELAY_CTRL,
+                    MPU6050_DELAYCTRL_DELAY_ES_SHADOW_BIT, buffer);
     return buffer[0];
 }
 /** Set external data shadow delay enabled status.
@@ -2266,9 +2252,9 @@ bool MPU6050::getExternalShadowDelayEnabled()
  * @see MPU6050_RA_I2C_MST_DELAY_CTRL
  * @see MPU6050_DELAYCTRL_DELAY_ES_SHADOW_BIT
  */
-void MPU6050::setExternalShadowDelayEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_MST_DELAY_CTRL, MPU6050_DELAYCTRL_DELAY_ES_SHADOW_BIT, enabled);
+void MPU6050::setExternalShadowDelayEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_MST_DELAY_CTRL,
+                     MPU6050_DELAYCTRL_DELAY_ES_SHADOW_BIT, enabled);
 }
 /** Get slave delay enabled status.
  * When a particular slave delay is enabled, the rate of access for the that
@@ -2281,15 +2267,15 @@ void MPU6050::setExternalShadowDelayEnabled(bool enabled)
  * and DLPF_CFG (register 26).
  *
  * For further information regarding I2C_MST_DLY, please refer to register 52.
- * For further information regarding the Sample Rate, please refer to register 25.
+ * For further information regarding the Sample Rate, please refer to register
+ *25.
  *
  * @param num Slave number (0-4)
  * @return Current slave delay enabled status.
  * @see MPU6050_RA_I2C_MST_DELAY_CTRL
  * @see MPU6050_DELAYCTRL_I2C_SLV0_DLY_EN_BIT
  */
-bool MPU6050::getSlaveDelayEnabled(uint8_t num)
-{
+bool MPU6050::getSlaveDelayEnabled(uint8_t num) {
     // MPU6050_DELAYCTRL_I2C_SLV4_DLY_EN_BIT is 4, SLV3 is 3, etc.
     if (num > 4) return 0;
     i2Cdev->readBit(devAddr, MPU6050_RA_I2C_MST_DELAY_CTRL, num, buffer);
@@ -2301,8 +2287,7 @@ bool MPU6050::getSlaveDelayEnabled(uint8_t num)
  * @see MPU6050_RA_I2C_MST_DELAY_CTRL
  * @see MPU6050_DELAYCTRL_I2C_SLV0_DLY_EN_BIT
  */
-void MPU6050::setSlaveDelayEnabled(uint8_t num, bool enabled)
-{
+void MPU6050::setSlaveDelayEnabled(uint8_t num, bool enabled) {
     i2Cdev->writeBit(devAddr, MPU6050_RA_I2C_MST_DELAY_CTRL, num, enabled);
 }
 
@@ -2314,9 +2299,9 @@ void MPU6050::setSlaveDelayEnabled(uint8_t num, bool enabled)
  * @see MPU6050_RA_SIGNAL_PATH_RESET
  * @see MPU6050_PATHRESET_GYRO_RESET_BIT
  */
-void MPU6050::resetGyroscopePath()
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_SIGNAL_PATH_RESET, MPU6050_PATHRESET_GYRO_RESET_BIT, true);
+void MPU6050::resetGyroscopePath() {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_SIGNAL_PATH_RESET,
+                     MPU6050_PATHRESET_GYRO_RESET_BIT, true);
 }
 /** Reset accelerometer signal path.
  * The reset will revert the signal path analog to digital converters and
@@ -2324,9 +2309,9 @@ void MPU6050::resetGyroscopePath()
  * @see MPU6050_RA_SIGNAL_PATH_RESET
  * @see MPU6050_PATHRESET_ACCEL_RESET_BIT
  */
-void MPU6050::resetAccelerometerPath()
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_SIGNAL_PATH_RESET, MPU6050_PATHRESET_ACCEL_RESET_BIT, true);
+void MPU6050::resetAccelerometerPath() {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_SIGNAL_PATH_RESET,
+                     MPU6050_PATHRESET_ACCEL_RESET_BIT, true);
 }
 /** Reset temperature sensor signal path.
  * The reset will revert the signal path analog to digital converters and
@@ -2334,9 +2319,9 @@ void MPU6050::resetAccelerometerPath()
  * @see MPU6050_RA_SIGNAL_PATH_RESET
  * @see MPU6050_PATHRESET_TEMP_RESET_BIT
  */
-void MPU6050::resetTemperaturePath()
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_SIGNAL_PATH_RESET, MPU6050_PATHRESET_TEMP_RESET_BIT, true);
+void MPU6050::resetTemperaturePath() {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_SIGNAL_PATH_RESET,
+                     MPU6050_PATHRESET_TEMP_RESET_BIT, true);
 }
 
 // MOT_DETECT_CTRL register
@@ -2355,9 +2340,10 @@ void MPU6050::resetTemperaturePath()
  * @see MPU6050_RA_MOT_DETECT_CTRL
  * @see MPU6050_DETECT_ACCEL_ON_DELAY_BIT
  */
-uint8_t MPU6050::getAccelerometerPowerOnDelay()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_MOT_DETECT_CTRL, MPU6050_DETECT_ACCEL_ON_DELAY_BIT, MPU6050_DETECT_ACCEL_ON_DELAY_LENGTH, buffer);
+uint8_t MPU6050::getAccelerometerPowerOnDelay() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_MOT_DETECT_CTRL,
+                     MPU6050_DETECT_ACCEL_ON_DELAY_BIT,
+                     MPU6050_DETECT_ACCEL_ON_DELAY_LENGTH, buffer);
     return buffer[0];
 }
 /** Set accelerometer power-on delay.
@@ -2366,9 +2352,10 @@ uint8_t MPU6050::getAccelerometerPowerOnDelay()
  * @see MPU6050_RA_MOT_DETECT_CTRL
  * @see MPU6050_DETECT_ACCEL_ON_DELAY_BIT
  */
-void MPU6050::setAccelerometerPowerOnDelay(uint8_t delay)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_MOT_DETECT_CTRL, MPU6050_DETECT_ACCEL_ON_DELAY_BIT, MPU6050_DETECT_ACCEL_ON_DELAY_LENGTH, delay);
+void MPU6050::setAccelerometerPowerOnDelay(uint8_t delay) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_MOT_DETECT_CTRL,
+                      MPU6050_DETECT_ACCEL_ON_DELAY_BIT,
+                      MPU6050_DETECT_ACCEL_ON_DELAY_LENGTH, delay);
 }
 /** Get Free Fall detection counter decrement configuration.
  * Detection is registered by the Free Fall detection module after accelerometer
@@ -2396,9 +2383,10 @@ void MPU6050::setAccelerometerPowerOnDelay(uint8_t delay)
  * @see MPU6050_RA_MOT_DETECT_CTRL
  * @see MPU6050_DETECT_FF_COUNT_BIT
  */
-uint8_t MPU6050::getFreefallDetectionCounterDecrement()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_MOT_DETECT_CTRL, MPU6050_DETECT_FF_COUNT_BIT, MPU6050_DETECT_FF_COUNT_LENGTH, buffer);
+uint8_t MPU6050::getFreefallDetectionCounterDecrement() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_MOT_DETECT_CTRL,
+                     MPU6050_DETECT_FF_COUNT_BIT,
+                     MPU6050_DETECT_FF_COUNT_LENGTH, buffer);
     return buffer[0];
 }
 /** Set Free Fall detection counter decrement configuration.
@@ -2407,9 +2395,10 @@ uint8_t MPU6050::getFreefallDetectionCounterDecrement()
  * @see MPU6050_RA_MOT_DETECT_CTRL
  * @see MPU6050_DETECT_FF_COUNT_BIT
  */
-void MPU6050::setFreefallDetectionCounterDecrement(uint8_t decrement)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_MOT_DETECT_CTRL, MPU6050_DETECT_FF_COUNT_BIT, MPU6050_DETECT_FF_COUNT_LENGTH, decrement);
+void MPU6050::setFreefallDetectionCounterDecrement(uint8_t decrement) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_MOT_DETECT_CTRL,
+                      MPU6050_DETECT_FF_COUNT_BIT,
+                      MPU6050_DETECT_FF_COUNT_LENGTH, decrement);
 }
 /** Get Motion detection counter decrement configuration.
  * Detection is registered by the Motion detection module after accelerometer
@@ -2434,9 +2423,10 @@ void MPU6050::setFreefallDetectionCounterDecrement(uint8_t decrement)
  * please refer to Registers 29 to 32.
  *
  */
-uint8_t MPU6050::getMotionDetectionCounterDecrement()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_MOT_DETECT_CTRL, MPU6050_DETECT_MOT_COUNT_BIT, MPU6050_DETECT_MOT_COUNT_LENGTH, buffer);
+uint8_t MPU6050::getMotionDetectionCounterDecrement() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_MOT_DETECT_CTRL,
+                     MPU6050_DETECT_MOT_COUNT_BIT,
+                     MPU6050_DETECT_MOT_COUNT_LENGTH, buffer);
     return buffer[0];
 }
 /** Set Motion detection counter decrement configuration.
@@ -2445,9 +2435,10 @@ uint8_t MPU6050::getMotionDetectionCounterDecrement()
  * @see MPU6050_RA_MOT_DETECT_CTRL
  * @see MPU6050_DETECT_MOT_COUNT_BIT
  */
-void MPU6050::setMotionDetectionCounterDecrement(uint8_t decrement)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_MOT_DETECT_CTRL, MPU6050_DETECT_MOT_COUNT_BIT, MPU6050_DETECT_MOT_COUNT_LENGTH, decrement);
+void MPU6050::setMotionDetectionCounterDecrement(uint8_t decrement) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_MOT_DETECT_CTRL,
+                      MPU6050_DETECT_MOT_COUNT_BIT,
+                      MPU6050_DETECT_MOT_COUNT_LENGTH, decrement);
 }
 
 // USER_CTRL register
@@ -2460,9 +2451,9 @@ void MPU6050::setMotionDetectionCounterDecrement(uint8_t decrement)
  * @see MPU6050_RA_USER_CTRL
  * @see MPU6050_USERCTRL_FIFO_EN_BIT
  */
-bool MPU6050::getFIFOEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_FIFO_EN_BIT, buffer);
+bool MPU6050::getFIFOEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_FIFO_EN_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set FIFO enabled status.
@@ -2471,9 +2462,9 @@ bool MPU6050::getFIFOEnabled()
  * @see MPU6050_RA_USER_CTRL
  * @see MPU6050_USERCTRL_FIFO_EN_BIT
  */
-void MPU6050::setFIFOEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_FIFO_EN_BIT, enabled);
+void MPU6050::setFIFOEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL,
+                     MPU6050_USERCTRL_FIFO_EN_BIT, enabled);
 }
 /** Get I2C Master Mode enabled status.
  * When this mode is enabled, the MPU-60X0 acts as the I2C Master to the
@@ -2486,9 +2477,9 @@ void MPU6050::setFIFOEnabled(bool enabled)
  * @see MPU6050_RA_USER_CTRL
  * @see MPU6050_USERCTRL_I2C_MST_EN_BIT
  */
-bool MPU6050::getI2CMasterModeEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_I2C_MST_EN_BIT, buffer);
+bool MPU6050::getI2CMasterModeEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_USER_CTRL,
+                    MPU6050_USERCTRL_I2C_MST_EN_BIT, buffer);
     return buffer[0];
 }
 /** Set I2C Master Mode enabled status.
@@ -2497,17 +2488,17 @@ bool MPU6050::getI2CMasterModeEnabled()
  * @see MPU6050_RA_USER_CTRL
  * @see MPU6050_USERCTRL_I2C_MST_EN_BIT
  */
-void MPU6050::setI2CMasterModeEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_I2C_MST_EN_BIT, enabled);
+void MPU6050::setI2CMasterModeEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL,
+                     MPU6050_USERCTRL_I2C_MST_EN_BIT, enabled);
 }
 /** Switch from I2C to SPI mode (MPU-6000 only)
  * If this is set, the primary SPI interface will be enabled in place of the
  * disabled primary I2C interface.
  */
-void MPU6050::switchSPIEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_I2C_IF_DIS_BIT, enabled);
+void MPU6050::switchSPIEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL,
+                     MPU6050_USERCTRL_I2C_IF_DIS_BIT, enabled);
 }
 /** Reset the FIFO.
  * This bit resets the FIFO buffer when set to 1 while FIFO_EN equals 0. This
@@ -2515,9 +2506,9 @@ void MPU6050::switchSPIEnabled(bool enabled)
  * @see MPU6050_RA_USER_CTRL
  * @see MPU6050_USERCTRL_FIFO_RESET_BIT
  */
-void MPU6050::resetFIFO()
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_FIFO_RESET_BIT, true);
+void MPU6050::resetFIFO() {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL,
+                     MPU6050_USERCTRL_FIFO_RESET_BIT, true);
 }
 /** Reset the I2C Master.
  * This bit resets the I2C Master when set to 1 while I2C_MST_EN equals 0.
@@ -2525,9 +2516,9 @@ void MPU6050::resetFIFO()
  * @see MPU6050_RA_USER_CTRL
  * @see MPU6050_USERCTRL_I2C_MST_RESET_BIT
  */
-void MPU6050::resetI2CMaster()
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_I2C_MST_RESET_BIT, true);
+void MPU6050::resetI2CMaster() {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL,
+                     MPU6050_USERCTRL_I2C_MST_RESET_BIT, true);
 }
 /** Reset all sensor registers and signal paths.
  * When set to 1, this bit resets the signal paths for all sensors (gyroscopes,
@@ -2541,9 +2532,9 @@ void MPU6050::resetI2CMaster()
  * @see MPU6050_RA_USER_CTRL
  * @see MPU6050_USERCTRL_SIG_COND_RESET_BIT
  */
-void MPU6050::resetSensors()
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_SIG_COND_RESET_BIT, true);
+void MPU6050::resetSensors() {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL,
+                     MPU6050_USERCTRL_SIG_COND_RESET_BIT, true);
 }
 
 // PWR_MGMT_1 register
@@ -2553,9 +2544,9 @@ void MPU6050::resetSensors()
  * @see MPU6050_RA_PWR_MGMT_1
  * @see MPU6050_PWR1_DEVICE_RESET_BIT
  */
-void MPU6050::reset()
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_DEVICE_RESET_BIT, true);
+void MPU6050::reset() {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_1,
+                     MPU6050_PWR1_DEVICE_RESET_BIT, true);
 }
 /** Get sleep mode status.
  * Setting the SLEEP bit in the register puts the device into very low power
@@ -2568,9 +2559,9 @@ void MPU6050::reset()
  * @see MPU6050_RA_PWR_MGMT_1
  * @see MPU6050_PWR1_SLEEP_BIT
  */
-bool MPU6050::getSleepEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_SLEEP_BIT, buffer);
+bool MPU6050::getSleepEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_SLEEP_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set sleep mode status.
@@ -2579,9 +2570,9 @@ bool MPU6050::getSleepEnabled()
  * @see MPU6050_RA_PWR_MGMT_1
  * @see MPU6050_PWR1_SLEEP_BIT
  */
-void MPU6050::setSleepEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_SLEEP_BIT, enabled);
+void MPU6050::setSleepEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_SLEEP_BIT,
+                     enabled);
 }
 /** Get wake cycle enabled status.
  * When this bit is set to 1 and SLEEP is disabled, the MPU-60X0 will cycle
@@ -2591,9 +2582,9 @@ void MPU6050::setSleepEnabled(bool enabled)
  * @see MPU6050_RA_PWR_MGMT_1
  * @see MPU6050_PWR1_CYCLE_BIT
  */
-bool MPU6050::getWakeCycleEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_CYCLE_BIT, buffer);
+bool MPU6050::getWakeCycleEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_CYCLE_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set wake cycle enabled status.
@@ -2602,9 +2593,9 @@ bool MPU6050::getWakeCycleEnabled()
  * @see MPU6050_RA_PWR_MGMT_1
  * @see MPU6050_PWR1_CYCLE_BIT
  */
-void MPU6050::setWakeCycleEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_CYCLE_BIT, enabled);
+void MPU6050::setWakeCycleEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_CYCLE_BIT,
+                     enabled);
 }
 /** Get temperature sensor enabled status.
  * Control the usage of the internal temperature sensor.
@@ -2617,10 +2608,10 @@ void MPU6050::setWakeCycleEnabled(bool enabled)
  * @see MPU6050_RA_PWR_MGMT_1
  * @see MPU6050_PWR1_TEMP_DIS_BIT
  */
-bool MPU6050::getTempSensorEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_TEMP_DIS_BIT, buffer);
-    return buffer[0] == 0; // 1 is actually disabled here
+bool MPU6050::getTempSensorEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_TEMP_DIS_BIT,
+                    buffer);
+    return buffer[0] == 0;  // 1 is actually disabled here
 }
 /** Set temperature sensor enabled status.
  * Note: this register stores the *disabled* value, but for consistency with the
@@ -2632,10 +2623,10 @@ bool MPU6050::getTempSensorEnabled()
  * @see MPU6050_RA_PWR_MGMT_1
  * @see MPU6050_PWR1_TEMP_DIS_BIT
  */
-void MPU6050::setTempSensorEnabled(bool enabled)
-{
+void MPU6050::setTempSensorEnabled(bool enabled) {
     // 1 is actually disabled here
-    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_TEMP_DIS_BIT, !enabled);
+    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_TEMP_DIS_BIT,
+                     !enabled);
 }
 /** Get clock source setting.
  * @return Current clock source setting
@@ -2643,9 +2634,9 @@ void MPU6050::setTempSensorEnabled(bool enabled)
  * @see MPU6050_PWR1_CLKSEL_BIT
  * @see MPU6050_PWR1_CLKSEL_LENGTH
  */
-uint8_t MPU6050::getClockSource()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_CLKSEL_BIT, MPU6050_PWR1_CLKSEL_LENGTH, buffer);
+uint8_t MPU6050::getClockSource() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_CLKSEL_BIT,
+                     MPU6050_PWR1_CLKSEL_LENGTH, buffer);
     return buffer[0];
 }
 /** Set clock source setting.
@@ -2657,7 +2648,8 @@ uint8_t MPU6050::getClockSource()
  * Upon power up, the MPU-60X0 clock source defaults to the internal oscillator.
  * However, it is highly recommended that the device be configured to use one of
  * the gyroscopes (or an external clock source) as the clock reference for
- * improved stability. The clock source can be selected according to the following table:
+ * improved stability. The clock source can be selected according to the
+ *following table:
  *
  * <pre>
  * CLK_SEL | Clock Source
@@ -2678,9 +2670,9 @@ uint8_t MPU6050::getClockSource()
  * @see MPU6050_PWR1_CLKSEL_BIT
  * @see MPU6050_PWR1_CLKSEL_LENGTH
  */
-void MPU6050::setClockSource(uint8_t source)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_CLKSEL_BIT, MPU6050_PWR1_CLKSEL_LENGTH, source);
+void MPU6050::setClockSource(uint8_t source) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_PWR_MGMT_1, MPU6050_PWR1_CLKSEL_BIT,
+                      MPU6050_PWR1_CLKSEL_LENGTH, source);
 }
 
 // PWR_MGMT_2 register
@@ -2708,18 +2700,20 @@ void MPU6050::setClockSource(uint8_t source)
  * @return Current wake frequency
  * @see MPU6050_RA_PWR_MGMT_2
  */
-uint8_t MPU6050::getWakeFrequency()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_LP_WAKE_CTRL_BIT, MPU6050_PWR2_LP_WAKE_CTRL_LENGTH, buffer);
+uint8_t MPU6050::getWakeFrequency() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_PWR_MGMT_2,
+                     MPU6050_PWR2_LP_WAKE_CTRL_BIT,
+                     MPU6050_PWR2_LP_WAKE_CTRL_LENGTH, buffer);
     return buffer[0];
 }
 /** Set wake frequency in Accel-Only Low Power Mode.
  * @param frequency New wake frequency
  * @see MPU6050_RA_PWR_MGMT_2
  */
-void MPU6050::setWakeFrequency(uint8_t frequency)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_LP_WAKE_CTRL_BIT, MPU6050_PWR2_LP_WAKE_CTRL_LENGTH, frequency);
+void MPU6050::setWakeFrequency(uint8_t frequency) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_PWR_MGMT_2,
+                      MPU6050_PWR2_LP_WAKE_CTRL_BIT,
+                      MPU6050_PWR2_LP_WAKE_CTRL_LENGTH, frequency);
 }
 
 /** Get X-axis accelerometer standby enabled status.
@@ -2728,9 +2722,9 @@ void MPU6050::setWakeFrequency(uint8_t frequency)
  * @see MPU6050_RA_PWR_MGMT_2
  * @see MPU6050_PWR2_STBY_XA_BIT
  */
-bool MPU6050::getStandbyXAccelEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_XA_BIT, buffer);
+bool MPU6050::getStandbyXAccelEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_XA_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set X-axis accelerometer standby enabled status.
@@ -2739,9 +2733,9 @@ bool MPU6050::getStandbyXAccelEnabled()
  * @see MPU6050_RA_PWR_MGMT_2
  * @see MPU6050_PWR2_STBY_XA_BIT
  */
-void MPU6050::setStandbyXAccelEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_XA_BIT, enabled);
+void MPU6050::setStandbyXAccelEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_XA_BIT,
+                     enabled);
 }
 /** Get Y-axis accelerometer standby enabled status.
  * If enabled, the Y-axis will not gather or report data (or use power).
@@ -2749,9 +2743,9 @@ void MPU6050::setStandbyXAccelEnabled(bool enabled)
  * @see MPU6050_RA_PWR_MGMT_2
  * @see MPU6050_PWR2_STBY_YA_BIT
  */
-bool MPU6050::getStandbyYAccelEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_YA_BIT, buffer);
+bool MPU6050::getStandbyYAccelEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_YA_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set Y-axis accelerometer standby enabled status.
@@ -2760,9 +2754,9 @@ bool MPU6050::getStandbyYAccelEnabled()
  * @see MPU6050_RA_PWR_MGMT_2
  * @see MPU6050_PWR2_STBY_YA_BIT
  */
-void MPU6050::setStandbyYAccelEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_YA_BIT, enabled);
+void MPU6050::setStandbyYAccelEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_YA_BIT,
+                     enabled);
 }
 /** Get Z-axis accelerometer standby enabled status.
  * If enabled, the Z-axis will not gather or report data (or use power).
@@ -2770,9 +2764,9 @@ void MPU6050::setStandbyYAccelEnabled(bool enabled)
  * @see MPU6050_RA_PWR_MGMT_2
  * @see MPU6050_PWR2_STBY_ZA_BIT
  */
-bool MPU6050::getStandbyZAccelEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_ZA_BIT, buffer);
+bool MPU6050::getStandbyZAccelEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_ZA_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set Z-axis accelerometer standby enabled status.
@@ -2781,9 +2775,9 @@ bool MPU6050::getStandbyZAccelEnabled()
  * @see MPU6050_RA_PWR_MGMT_2
  * @see MPU6050_PWR2_STBY_ZA_BIT
  */
-void MPU6050::setStandbyZAccelEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_ZA_BIT, enabled);
+void MPU6050::setStandbyZAccelEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_ZA_BIT,
+                     enabled);
 }
 /** Get X-axis gyroscope standby enabled status.
  * If enabled, the X-axis will not gather or report data (or use power).
@@ -2791,9 +2785,9 @@ void MPU6050::setStandbyZAccelEnabled(bool enabled)
  * @see MPU6050_RA_PWR_MGMT_2
  * @see MPU6050_PWR2_STBY_XG_BIT
  */
-bool MPU6050::getStandbyXGyroEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_XG_BIT, buffer);
+bool MPU6050::getStandbyXGyroEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_XG_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set X-axis gyroscope standby enabled status.
@@ -2802,9 +2796,9 @@ bool MPU6050::getStandbyXGyroEnabled()
  * @see MPU6050_RA_PWR_MGMT_2
  * @see MPU6050_PWR2_STBY_XG_BIT
  */
-void MPU6050::setStandbyXGyroEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_XG_BIT, enabled);
+void MPU6050::setStandbyXGyroEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_XG_BIT,
+                     enabled);
 }
 /** Get Y-axis gyroscope standby enabled status.
  * If enabled, the Y-axis will not gather or report data (or use power).
@@ -2812,9 +2806,9 @@ void MPU6050::setStandbyXGyroEnabled(bool enabled)
  * @see MPU6050_RA_PWR_MGMT_2
  * @see MPU6050_PWR2_STBY_YG_BIT
  */
-bool MPU6050::getStandbyYGyroEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_YG_BIT, buffer);
+bool MPU6050::getStandbyYGyroEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_YG_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set Y-axis gyroscope standby enabled status.
@@ -2823,9 +2817,9 @@ bool MPU6050::getStandbyYGyroEnabled()
  * @see MPU6050_RA_PWR_MGMT_2
  * @see MPU6050_PWR2_STBY_YG_BIT
  */
-void MPU6050::setStandbyYGyroEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_YG_BIT, enabled);
+void MPU6050::setStandbyYGyroEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_YG_BIT,
+                     enabled);
 }
 /** Get Z-axis gyroscope standby enabled status.
  * If enabled, the Z-axis will not gather or report data (or use power).
@@ -2833,9 +2827,9 @@ void MPU6050::setStandbyYGyroEnabled(bool enabled)
  * @see MPU6050_RA_PWR_MGMT_2
  * @see MPU6050_PWR2_STBY_ZG_BIT
  */
-bool MPU6050::getStandbyZGyroEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_ZG_BIT, buffer);
+bool MPU6050::getStandbyZGyroEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_ZG_BIT,
+                    buffer);
     return buffer[0];
 }
 /** Set Z-axis gyroscope standby enabled status.
@@ -2844,9 +2838,9 @@ bool MPU6050::getStandbyZGyroEnabled()
  * @see MPU6050_RA_PWR_MGMT_2
  * @see MPU6050_PWR2_STBY_ZG_BIT
  */
-void MPU6050::setStandbyZGyroEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_ZG_BIT, enabled);
+void MPU6050::setStandbyZGyroEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_PWR_MGMT_2, MPU6050_PWR2_STBY_ZG_BIT,
+                     enabled);
 }
 
 // FIFO_COUNT* registers
@@ -2858,8 +2852,7 @@ void MPU6050::setStandbyZGyroEnabled(bool enabled)
  * set of sensor data bound to be stored in the FIFO (register 35 and 36).
  * @return Current FIFO buffer size
  */
-uint16_t MPU6050::getFIFOCount()
-{
+uint16_t MPU6050::getFIFOCount() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_FIFO_COUNTH, 2, buffer);
     return (((uint16_t)buffer[0]) << 8) | buffer[1];
 }
@@ -2891,21 +2884,18 @@ uint16_t MPU6050::getFIFOCount()
  *
  * @return Byte from FIFO buffer
  */
-uint8_t MPU6050::getFIFOByte()
-{
+uint8_t MPU6050::getFIFOByte() {
     i2Cdev->readByte(devAddr, MPU6050_RA_FIFO_R_W, buffer);
     return buffer[0];
 }
-void MPU6050::getFIFOBytes(uint8_t *data, uint8_t length)
-{
+void MPU6050::getFIFOBytes(uint8_t* data, uint8_t length) {
     i2Cdev->readBytes(devAddr, MPU6050_RA_FIFO_R_W, length, data);
 }
 /** Write byte to FIFO buffer.
  * @see getFIFOByte()
  * @see MPU6050_RA_FIFO_R_W
  */
-void MPU6050::setFIFOByte(uint8_t data)
-{
+void MPU6050::setFIFOByte(uint8_t data) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_FIFO_R_W, data);
 }
 
@@ -2918,9 +2908,9 @@ void MPU6050::setFIFOByte(uint8_t data)
  * @see MPU6050_WHO_AM_I_BIT
  * @see MPU6050_WHO_AM_I_LENGTH
  */
-uint8_t MPU6050::getDeviceID()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_WHO_AM_I, MPU6050_WHO_AM_I_BIT, MPU6050_WHO_AM_I_LENGTH, buffer);
+uint8_t MPU6050::getDeviceID() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_WHO_AM_I, MPU6050_WHO_AM_I_BIT,
+                     MPU6050_WHO_AM_I_LENGTH, buffer);
     return buffer[0];
 }
 /** Set Device ID.
@@ -2932,253 +2922,234 @@ uint8_t MPU6050::getDeviceID()
  * @see MPU6050_WHO_AM_I_BIT
  * @see MPU6050_WHO_AM_I_LENGTH
  */
-void MPU6050::setDeviceID(uint8_t id)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_WHO_AM_I, MPU6050_WHO_AM_I_BIT, MPU6050_WHO_AM_I_LENGTH, id);
+void MPU6050::setDeviceID(uint8_t id) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_WHO_AM_I, MPU6050_WHO_AM_I_BIT,
+                      MPU6050_WHO_AM_I_LENGTH, id);
 }
 
 // ======== UNDOCUMENTED/DMP REGISTERS/METHODS ========
 
 // XG_OFFS_TC register
 
-uint8_t MPU6050::getOTPBankValid()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_XG_OFFS_TC, MPU6050_TC_OTP_BNK_VLD_BIT, buffer);
+uint8_t MPU6050::getOTPBankValid() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_XG_OFFS_TC, MPU6050_TC_OTP_BNK_VLD_BIT,
+                    buffer);
     return buffer[0];
 }
-void MPU6050::setOTPBankValid(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_XG_OFFS_TC, MPU6050_TC_OTP_BNK_VLD_BIT, enabled);
+void MPU6050::setOTPBankValid(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_XG_OFFS_TC, MPU6050_TC_OTP_BNK_VLD_BIT,
+                     enabled);
 }
-int8_t MPU6050::getXGyroOffsetTC()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_XG_OFFS_TC, MPU6050_TC_OFFSET_BIT, MPU6050_TC_OFFSET_LENGTH, buffer);
+int8_t MPU6050::getXGyroOffsetTC() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_XG_OFFS_TC, MPU6050_TC_OFFSET_BIT,
+                     MPU6050_TC_OFFSET_LENGTH, buffer);
     return buffer[0];
 }
-void MPU6050::setXGyroOffsetTC(int8_t offset)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_XG_OFFS_TC, MPU6050_TC_OFFSET_BIT, MPU6050_TC_OFFSET_LENGTH, offset);
+void MPU6050::setXGyroOffsetTC(int8_t offset) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_XG_OFFS_TC, MPU6050_TC_OFFSET_BIT,
+                      MPU6050_TC_OFFSET_LENGTH, offset);
 }
 
 // YG_OFFS_TC register
 
-int8_t MPU6050::getYGyroOffsetTC()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_YG_OFFS_TC, MPU6050_TC_OFFSET_BIT, MPU6050_TC_OFFSET_LENGTH, buffer);
+int8_t MPU6050::getYGyroOffsetTC() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_YG_OFFS_TC, MPU6050_TC_OFFSET_BIT,
+                     MPU6050_TC_OFFSET_LENGTH, buffer);
     return buffer[0];
 }
-void MPU6050::setYGyroOffsetTC(int8_t offset)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_YG_OFFS_TC, MPU6050_TC_OFFSET_BIT, MPU6050_TC_OFFSET_LENGTH, offset);
+void MPU6050::setYGyroOffsetTC(int8_t offset) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_YG_OFFS_TC, MPU6050_TC_OFFSET_BIT,
+                      MPU6050_TC_OFFSET_LENGTH, offset);
 }
 
 // ZG_OFFS_TC register
 
-int8_t MPU6050::getZGyroOffsetTC()
-{
-    i2Cdev->readBits(devAddr, MPU6050_RA_ZG_OFFS_TC, MPU6050_TC_OFFSET_BIT, MPU6050_TC_OFFSET_LENGTH, buffer);
+int8_t MPU6050::getZGyroOffsetTC() {
+    i2Cdev->readBits(devAddr, MPU6050_RA_ZG_OFFS_TC, MPU6050_TC_OFFSET_BIT,
+                     MPU6050_TC_OFFSET_LENGTH, buffer);
     return buffer[0];
 }
-void MPU6050::setZGyroOffsetTC(int8_t offset)
-{
-    i2Cdev->writeBits(devAddr, MPU6050_RA_ZG_OFFS_TC, MPU6050_TC_OFFSET_BIT, MPU6050_TC_OFFSET_LENGTH, offset);
+void MPU6050::setZGyroOffsetTC(int8_t offset) {
+    i2Cdev->writeBits(devAddr, MPU6050_RA_ZG_OFFS_TC, MPU6050_TC_OFFSET_BIT,
+                      MPU6050_TC_OFFSET_LENGTH, offset);
 }
 
 // X_FINE_GAIN register
 
-int8_t MPU6050::getXFineGain()
-{
+int8_t MPU6050::getXFineGain() {
     i2Cdev->readByte(devAddr, MPU6050_RA_X_FINE_GAIN, buffer);
     return buffer[0];
 }
-void MPU6050::setXFineGain(int8_t gain)
-{
+void MPU6050::setXFineGain(int8_t gain) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_X_FINE_GAIN, gain);
 }
 
 // Y_FINE_GAIN register
 
-int8_t MPU6050::getYFineGain()
-{
+int8_t MPU6050::getYFineGain() {
     i2Cdev->readByte(devAddr, MPU6050_RA_Y_FINE_GAIN, buffer);
     return buffer[0];
 }
-void MPU6050::setYFineGain(int8_t gain)
-{
+void MPU6050::setYFineGain(int8_t gain) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_Y_FINE_GAIN, gain);
 }
 
 // Z_FINE_GAIN register
 
-int8_t MPU6050::getZFineGain()
-{
+int8_t MPU6050::getZFineGain() {
     i2Cdev->readByte(devAddr, MPU6050_RA_Z_FINE_GAIN, buffer);
     return buffer[0];
 }
-void MPU6050::setZFineGain(int8_t gain)
-{
+void MPU6050::setZFineGain(int8_t gain) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_Z_FINE_GAIN, gain);
 }
 
 // XA_OFFS_* registers
 
-int16_t MPU6050::getXAccelOffset()
-{
+int16_t MPU6050::getXAccelOffset() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_XA_OFFS_H, 2, buffer);
     return (((int16_t)buffer[0]) << 8) | buffer[1];
 }
-void MPU6050::setXAccelOffset(int16_t offset)
-{
+void MPU6050::setXAccelOffset(int16_t offset) {
     i2Cdev->writeWord(devAddr, MPU6050_RA_XA_OFFS_H, offset);
 }
 
 // YA_OFFS_* register
 
-int16_t MPU6050::getYAccelOffset()
-{
+int16_t MPU6050::getYAccelOffset() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_YA_OFFS_H, 2, buffer);
     return (((int16_t)buffer[0]) << 8) | buffer[1];
 }
-void MPU6050::setYAccelOffset(int16_t offset)
-{
+void MPU6050::setYAccelOffset(int16_t offset) {
     i2Cdev->writeWord(devAddr, MPU6050_RA_YA_OFFS_H, offset);
 }
 
 // ZA_OFFS_* register
 
-int16_t MPU6050::getZAccelOffset()
-{
+int16_t MPU6050::getZAccelOffset() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_ZA_OFFS_H, 2, buffer);
     return (((int16_t)buffer[0]) << 8) | buffer[1];
 }
-void MPU6050::setZAccelOffset(int16_t offset)
-{
+void MPU6050::setZAccelOffset(int16_t offset) {
     i2Cdev->writeWord(devAddr, MPU6050_RA_ZA_OFFS_H, offset);
 }
 
 // XG_OFFS_USR* registers
 
-int16_t MPU6050::getXGyroOffset()
-{
+int16_t MPU6050::getXGyroOffset() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_XG_OFFS_USRH, 2, buffer);
     return (((int16_t)buffer[0]) << 8) | buffer[1];
 }
-void MPU6050::setXGyroOffset(int16_t offset)
-{
+void MPU6050::setXGyroOffset(int16_t offset) {
     i2Cdev->writeWord(devAddr, MPU6050_RA_XG_OFFS_USRH, offset);
 }
 
 // YG_OFFS_USR* register
 
-int16_t MPU6050::getYGyroOffset()
-{
+int16_t MPU6050::getYGyroOffset() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_YG_OFFS_USRH, 2, buffer);
     return (((int16_t)buffer[0]) << 8) | buffer[1];
 }
-void MPU6050::setYGyroOffset(int16_t offset)
-{
+void MPU6050::setYGyroOffset(int16_t offset) {
     i2Cdev->writeWord(devAddr, MPU6050_RA_YG_OFFS_USRH, offset);
 }
 
 // ZG_OFFS_USR* register
 
-int16_t MPU6050::getZGyroOffset()
-{
+int16_t MPU6050::getZGyroOffset() {
     i2Cdev->readBytes(devAddr, MPU6050_RA_ZG_OFFS_USRH, 2, buffer);
     return (((int16_t)buffer[0]) << 8) | buffer[1];
 }
-void MPU6050::setZGyroOffset(int16_t offset)
-{
+void MPU6050::setZGyroOffset(int16_t offset) {
     i2Cdev->writeWord(devAddr, MPU6050_RA_ZG_OFFS_USRH, offset);
 }
 
 // INT_ENABLE register (DMP functions)
 
-bool MPU6050::getIntPLLReadyEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_PLL_RDY_INT_BIT, buffer);
+bool MPU6050::getIntPLLReadyEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE,
+                    MPU6050_INTERRUPT_PLL_RDY_INT_BIT, buffer);
     return buffer[0];
 }
-void MPU6050::setIntPLLReadyEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_PLL_RDY_INT_BIT, enabled);
+void MPU6050::setIntPLLReadyEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE,
+                     MPU6050_INTERRUPT_PLL_RDY_INT_BIT, enabled);
 }
-bool MPU6050::getIntDMPEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_DMP_INT_BIT, buffer);
+bool MPU6050::getIntDMPEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_ENABLE,
+                    MPU6050_INTERRUPT_DMP_INT_BIT, buffer);
     return buffer[0];
 }
-void MPU6050::setIntDMPEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE, MPU6050_INTERRUPT_DMP_INT_BIT, enabled);
+void MPU6050::setIntDMPEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_INT_ENABLE,
+                     MPU6050_INTERRUPT_DMP_INT_BIT, enabled);
 }
 
 // DMP_INT_STATUS
 
-bool MPU6050::getDMPInt5Status()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_DMP_INT_STATUS, MPU6050_DMPINT_5_BIT, buffer);
+bool MPU6050::getDMPInt5Status() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_DMP_INT_STATUS, MPU6050_DMPINT_5_BIT,
+                    buffer);
     return buffer[0];
 }
-bool MPU6050::getDMPInt4Status()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_DMP_INT_STATUS, MPU6050_DMPINT_4_BIT, buffer);
+bool MPU6050::getDMPInt4Status() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_DMP_INT_STATUS, MPU6050_DMPINT_4_BIT,
+                    buffer);
     return buffer[0];
 }
-bool MPU6050::getDMPInt3Status()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_DMP_INT_STATUS, MPU6050_DMPINT_3_BIT, buffer);
+bool MPU6050::getDMPInt3Status() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_DMP_INT_STATUS, MPU6050_DMPINT_3_BIT,
+                    buffer);
     return buffer[0];
 }
-bool MPU6050::getDMPInt2Status()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_DMP_INT_STATUS, MPU6050_DMPINT_2_BIT, buffer);
+bool MPU6050::getDMPInt2Status() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_DMP_INT_STATUS, MPU6050_DMPINT_2_BIT,
+                    buffer);
     return buffer[0];
 }
-bool MPU6050::getDMPInt1Status()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_DMP_INT_STATUS, MPU6050_DMPINT_1_BIT, buffer);
+bool MPU6050::getDMPInt1Status() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_DMP_INT_STATUS, MPU6050_DMPINT_1_BIT,
+                    buffer);
     return buffer[0];
 }
-bool MPU6050::getDMPInt0Status()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_DMP_INT_STATUS, MPU6050_DMPINT_0_BIT, buffer);
+bool MPU6050::getDMPInt0Status() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_DMP_INT_STATUS, MPU6050_DMPINT_0_BIT,
+                    buffer);
     return buffer[0];
 }
 
 // INT_STATUS register (DMP functions)
 
-bool MPU6050::getIntPLLReadyStatus()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS, MPU6050_INTERRUPT_PLL_RDY_INT_BIT, buffer);
+bool MPU6050::getIntPLLReadyStatus() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS,
+                    MPU6050_INTERRUPT_PLL_RDY_INT_BIT, buffer);
     return buffer[0];
 }
-bool MPU6050::getIntDMPStatus()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS, MPU6050_INTERRUPT_DMP_INT_BIT, buffer);
+bool MPU6050::getIntDMPStatus() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_INT_STATUS,
+                    MPU6050_INTERRUPT_DMP_INT_BIT, buffer);
     return buffer[0];
 }
 
 // USER_CTRL register (DMP functions)
 
-bool MPU6050::getDMPEnabled()
-{
-    i2Cdev->readBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_DMP_EN_BIT, buffer);
+bool MPU6050::getDMPEnabled() {
+    i2Cdev->readBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_DMP_EN_BIT,
+                    buffer);
     return buffer[0];
 }
-void MPU6050::setDMPEnabled(bool enabled)
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_DMP_EN_BIT, enabled);
+void MPU6050::setDMPEnabled(bool enabled) {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_DMP_EN_BIT,
+                     enabled);
 }
-void MPU6050::resetDMP()
-{
-    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL, MPU6050_USERCTRL_DMP_RESET_BIT, true);
+void MPU6050::resetDMP() {
+    i2Cdev->writeBit(devAddr, MPU6050_RA_USER_CTRL,
+                     MPU6050_USERCTRL_DMP_RESET_BIT, true);
 }
 
 // BANK_SEL register
 
-void MPU6050::setMemoryBank(uint8_t bank, bool prefetchEnabled, bool userBank)
-{
+void MPU6050::setMemoryBank(uint8_t bank, bool prefetchEnabled, bool userBank) {
     bank &= 0x1F;
     if (userBank) bank |= 0x20;
     if (prefetchEnabled) bank |= 0x40;
@@ -3187,24 +3158,21 @@ void MPU6050::setMemoryBank(uint8_t bank, bool prefetchEnabled, bool userBank)
 
 // MEM_START_ADDR register
 
-void MPU6050::setMemoryStartAddress(uint8_t address)
-{
+void MPU6050::setMemoryStartAddress(uint8_t address) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_MEM_START_ADDR, address);
 }
 
 // MEM_R_W register
 
-uint8_t MPU6050::readMemoryByte()
-{
+uint8_t MPU6050::readMemoryByte() {
     i2Cdev->readByte(devAddr, MPU6050_RA_MEM_R_W, buffer);
     return buffer[0];
 }
-void MPU6050::writeMemoryByte(uint8_t data)
-{
+void MPU6050::writeMemoryByte(uint8_t data) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_MEM_R_W, data);
 }
-void MPU6050::readMemoryBlock(uint8_t *data, uint16_t dataSize, uint8_t bank, uint8_t address)
-{
+void MPU6050::readMemoryBlock(uint8_t* data, uint16_t dataSize, uint8_t bank,
+                              uint8_t address) {
     setMemoryBank(bank);
     setMemoryStartAddress(address);
     uint8_t chunkSize;
@@ -3235,17 +3203,19 @@ void MPU6050::readMemoryBlock(uint8_t *data, uint16_t dataSize, uint8_t bank, ui
         }
     }
 }
-bool MPU6050::writeMemoryBlock(const uint8_t *data, uint16_t dataSize, uint8_t bank, uint8_t address, bool verify, bool useProgMem)
-{
+bool MPU6050::writeMemoryBlock(const uint8_t* data, uint16_t dataSize,
+                               uint8_t bank, uint8_t address, bool verify,
+                               bool useProgMem) {
     setMemoryBank(bank);
     setMemoryStartAddress(address);
     uint8_t chunkSize;
-    uint8_t *verifyBuffer = nullptr;
-    uint8_t *progBuffer = nullptr;
+    uint8_t* verifyBuffer = nullptr;
+    uint8_t* progBuffer = nullptr;
     uint16_t i;
     uint8_t j;
-    if (verify) verifyBuffer = (uint8_t *)malloc(MPU6050_DMP_MEMORY_CHUNK_SIZE);
-    if (useProgMem) progBuffer = (uint8_t *)malloc(MPU6050_DMP_MEMORY_CHUNK_SIZE);
+    if (verify) verifyBuffer = (uint8_t*)malloc(MPU6050_DMP_MEMORY_CHUNK_SIZE);
+    if (useProgMem)
+        progBuffer = (uint8_t*)malloc(MPU6050_DMP_MEMORY_CHUNK_SIZE);
     for (i = 0; i < dataSize;) {
         // determine correct chunk size according to bank position and data size
         chunkSize = MPU6050_DMP_MEMORY_CHUNK_SIZE;
@@ -3258,10 +3228,11 @@ bool MPU6050::writeMemoryBlock(const uint8_t *data, uint16_t dataSize, uint8_t b
 
         if (useProgMem) {
             // write the chunk of data as specified
-            for (j = 0; j < chunkSize; j++) progBuffer[j] = pgm_read_byte(data + i + j);
+            for (j = 0; j < chunkSize; j++)
+                progBuffer[j] = pgm_read_byte(data + i + j);
         } else {
             // write the chunk of data as specified
-            progBuffer = (uint8_t *)data + i;
+            progBuffer = (uint8_t*)data + i;
         }
 
         i2Cdev->writeBytes(devAddr, MPU6050_RA_MEM_R_W, chunkSize, progBuffer);
@@ -3270,7 +3241,8 @@ bool MPU6050::writeMemoryBlock(const uint8_t *data, uint16_t dataSize, uint8_t b
         if (verify && verifyBuffer) {
             setMemoryBank(bank);
             setMemoryStartAddress(address);
-            i2Cdev->readBytes(devAddr, MPU6050_RA_MEM_R_W, chunkSize, verifyBuffer);
+            i2Cdev->readBytes(devAddr, MPU6050_RA_MEM_R_W, chunkSize,
+                              verifyBuffer);
             if (memcmp(progBuffer, verifyBuffer, chunkSize) != 0) {
                 /*Serial.print("Block write verification error, bank ");
                 Serial.print(bank, DEC);
@@ -3291,7 +3263,7 @@ bool MPU6050::writeMemoryBlock(const uint8_t *data, uint16_t dataSize, uint8_t b
                 Serial.print("\n");*/
                 free(verifyBuffer);
                 if (useProgMem) free(progBuffer);
-                return false; // uh oh.
+                return false;  // uh oh.
             }
         }
 
@@ -3312,17 +3284,18 @@ bool MPU6050::writeMemoryBlock(const uint8_t *data, uint16_t dataSize, uint8_t b
     if (useProgMem) free(progBuffer);
     return true;
 }
-bool MPU6050::writeProgMemoryBlock(const uint8_t *data, uint16_t dataSize, uint8_t bank, uint8_t address, bool verify)
-{
+bool MPU6050::writeProgMemoryBlock(const uint8_t* data, uint16_t dataSize,
+                                   uint8_t bank, uint8_t address, bool verify) {
     return writeMemoryBlock(data, dataSize, bank, address, verify, true);
 }
-bool MPU6050::writeDMPConfigurationSet(const uint8_t *data, uint16_t dataSize, bool useProgMem)
-{
-    uint8_t *progBuffer, success, special;
+bool MPU6050::writeDMPConfigurationSet(const uint8_t* data, uint16_t dataSize,
+                                       bool useProgMem) {
+    uint8_t* progBuffer, success, special;
     progBuffer = nullptr;
     uint16_t i, j;
     if (useProgMem) {
-        progBuffer = (uint8_t *)malloc(8); // assume 8-byte blocks, realloc later if necessary
+        progBuffer = (uint8_t*)malloc(
+            8);  // assume 8-byte blocks, realloc later if necessary
     }
 
     // config set data is a long string of blocks with the following structure:
@@ -3349,10 +3322,12 @@ bool MPU6050::writeDMPConfigurationSet(const uint8_t *data, uint16_t dataSize, b
             Serial.print(", length=");
             Serial.println(length);*/
             if (useProgMem) {
-                if (sizeof(progBuffer) < length) progBuffer = (uint8_t *)realloc(progBuffer, length);
-                for (j = 0; j < length; j++) progBuffer[j] = pgm_read_byte(data + i + j);
+                if (sizeof(progBuffer) < length)
+                    progBuffer = (uint8_t*)realloc(progBuffer, length);
+                for (j = 0; j < length; j++)
+                    progBuffer[j] = pgm_read_byte(data + i + j);
             } else {
-                progBuffer = (uint8_t *)data + i;
+                progBuffer = (uint8_t*)data + i;
             }
             success = writeMemoryBlock(progBuffer, length, bank, offset, true);
             i += length;
@@ -3360,7 +3335,8 @@ bool MPU6050::writeDMPConfigurationSet(const uint8_t *data, uint16_t dataSize, b
             // special instruction
             // NOTE: this kind of behavior (what and when to do certain things)
             // is totally undocumented. This code is in here based on observed
-            // behavior only, and exactly why (or even whether) it has to be here
+            // behavior only, and exactly why (or even whether) it has to be
+            // here
             // is anybody's guess for now.
             if (useProgMem) {
                 special = pgm_read_byte(data + i++);
@@ -3373,10 +3349,11 @@ bool MPU6050::writeDMPConfigurationSet(const uint8_t *data, uint16_t dataSize, b
             if (special == 0x01) {
                 // enable DMP-related interrupts
 
-                //setIntZeroMotionEnabled(true);
-                //setIntFIFOBufferOverflowEnabled(true);
-                //setIntDMPEnabled(true);
-                i2Cdev->writeByte(devAddr, MPU6050_RA_INT_ENABLE, 0x32);  // single operation
+                // setIntZeroMotionEnabled(true);
+                // setIntFIFOBufferOverflowEnabled(true);
+                // setIntDMPEnabled(true);
+                i2Cdev->writeByte(devAddr, MPU6050_RA_INT_ENABLE,
+                                  0x32);  // single operation
 
                 success = true;
             } else {
@@ -3387,37 +3364,33 @@ bool MPU6050::writeDMPConfigurationSet(const uint8_t *data, uint16_t dataSize, b
 
         if (!success) {
             if (useProgMem) free(progBuffer);
-            return false; // uh oh
+            return false;  // uh oh
         }
     }
     if (useProgMem) free(progBuffer);
     return true;
 }
-bool MPU6050::writeProgDMPConfigurationSet(const uint8_t *data, uint16_t dataSize)
-{
+bool MPU6050::writeProgDMPConfigurationSet(const uint8_t* data,
+                                           uint16_t dataSize) {
     return writeDMPConfigurationSet(data, dataSize, false);
 }
 
 // DMP_CFG_1 register
 
-uint8_t MPU6050::getDMPConfig1()
-{
+uint8_t MPU6050::getDMPConfig1() {
     i2Cdev->readByte(devAddr, MPU6050_RA_DMP_CFG_1, buffer);
     return buffer[0];
 }
-void MPU6050::setDMPConfig1(uint8_t config)
-{
+void MPU6050::setDMPConfig1(uint8_t config) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_DMP_CFG_1, config);
 }
 
 // DMP_CFG_2 register
 
-uint8_t MPU6050::getDMPConfig2()
-{
+uint8_t MPU6050::getDMPConfig2() {
     i2Cdev->readByte(devAddr, MPU6050_RA_DMP_CFG_2, buffer);
     return buffer[0];
 }
-void MPU6050::setDMPConfig2(uint8_t config)
-{
+void MPU6050::setDMPConfig2(uint8_t config) {
     i2Cdev->writeByte(devAddr, MPU6050_RA_DMP_CFG_2, config);
 }

--- a/lib/drivers/mpu-6050/MPU6050.h
+++ b/lib/drivers/mpu-6050/MPU6050.h
@@ -406,8 +406,8 @@ class MPU6050 {
     private:
         I2Cdev *i2Cdev;
     public:
-        MPU6050();
-        MPU6050(uint8_t address, PinName i2cSda, PinName i2cScl);
+        MPU6050(std::shared_ptr<SharedI2C> sharedI2C);
+        MPU6050(std::shared_ptr<SharedI2C> sharedI2C, uint8_t address);
 
         void initialize();
         bool testConnection();

--- a/lib/drivers/mpu-6050/MPU6050.h
+++ b/lib/drivers/mpu-6050/MPU6050.h
@@ -405,7 +405,6 @@ THE SOFTWARE.
 class MPU6050 {
     private:
         I2Cdev *i2Cdev;
-        Serial debugSerial;
     public:
         MPU6050();
         MPU6050(uint8_t address, PinName i2cSda, PinName i2cScl);

--- a/lib/drivers/mpu-6050/MPU6050.h
+++ b/lib/drivers/mpu-6050/MPU6050.h
@@ -1,19 +1,24 @@
-//ported from arduino library: https://github.com/jrowberg/i2cdevlib/tree/master/Arduino/MPU6050
-//written by szymon gaertig (email: szymon@gaertig.com.pl)
+// ported from arduino library:
+// https://github.com/jrowberg/i2cdevlib/tree/master/Arduino/MPU6050
+// written by szymon gaertig (email: szymon@gaertig.com.pl)
 //
-//Changelog: 
-//2013-01-08 - first beta release
+// Changelog:
+// 2013-01-08 - first beta release
 
 // I2Cdev library collection - MPU6050 I2C device class
-// Based on InvenSense MPU-6050 register map document rev. 2.0, 5/19/2011 (RM-MPU-6000A-00)
+// Based on InvenSense MPU-6050 register map document rev. 2.0, 5/19/2011
+// (RM-MPU-6000A-00)
 // 10/3/2011 by Jeff Rowberg <jeff@rowberg.net>
-// Updates should (hopefully) always be available at https://github.com/jrowberg/i2cdevlib
+// Updates should (hopefully) always be available at
+// https://github.com/jrowberg/i2cdevlib
 //
 // Changelog:
 //     ... - ongoing debug release
 
-// NOTE: THIS IS ONLY A PARIAL RELEASE. THIS DEVICE CLASS IS CURRENTLY UNDERGOING ACTIVE
-// DEVELOPMENT AND IS STILL MISSING SOME IMPORTANT FEATURES. PLEASE KEEP THIS IN MIND IF
+// NOTE: THIS IS ONLY A PARIAL RELEASE. THIS DEVICE CLASS IS CURRENTLY
+// UNDERGOING ACTIVE
+// DEVELOPMENT AND IS STILL MISSING SOME IMPORTANT FEATURES. PLEASE KEEP THIS IN
+// MIND IF
 // YOU DECIDE TO USE THIS PARTICULAR CODE FOR ANYTHING.
 
 /* ============================================
@@ -46,76 +51,80 @@ THE SOFTWARE.
 #include "I2Cdev.h"
 #include "helper_3dmath.h"
 
-#define MPU6050_ADDRESS_AD0_LOW     0x68 // address pin low (GND), default for InvenSense evaluation board
-#define MPU6050_ADDRESS_AD0_HIGH    0x69 // address pin high (VCC)
-#define MPU6050_DEFAULT_ADDRESS     MPU6050_ADDRESS_AD0_LOW
+#define MPU6050_ADDRESS_AD0_LOW \
+    0x68  // address pin low (GND), default for InvenSense evaluation board
+#define MPU6050_ADDRESS_AD0_HIGH 0x69  // address pin high (VCC)
+#define MPU6050_DEFAULT_ADDRESS MPU6050_ADDRESS_AD0_LOW
 
-#define MPU6050_RA_XG_OFFS_TC       0x00 //[7] PWR_MODE, [6:1] XG_OFFS_TC, [0] OTP_BNK_VLD
-#define MPU6050_RA_YG_OFFS_TC       0x01 //[7] PWR_MODE, [6:1] YG_OFFS_TC, [0] OTP_BNK_VLD
-#define MPU6050_RA_ZG_OFFS_TC       0x02 //[7] PWR_MODE, [6:1] ZG_OFFS_TC, [0] OTP_BNK_VLD
-#define MPU6050_RA_X_FINE_GAIN      0x03 //[7:0] X_FINE_GAIN
-#define MPU6050_RA_Y_FINE_GAIN      0x04 //[7:0] Y_FINE_GAIN
-#define MPU6050_RA_Z_FINE_GAIN      0x05 //[7:0] Z_FINE_GAIN
-#define MPU6050_RA_XA_OFFS_H        0x06 //[15:0] XA_OFFS
-#define MPU6050_RA_XA_OFFS_L_TC     0x07
-#define MPU6050_RA_YA_OFFS_H        0x08 //[15:0] YA_OFFS
-#define MPU6050_RA_YA_OFFS_L_TC     0x09
-#define MPU6050_RA_ZA_OFFS_H        0x0A //[15:0] ZA_OFFS
-#define MPU6050_RA_ZA_OFFS_L_TC     0x0B
-#define MPU6050_RA_XG_OFFS_USRH     0x13 //[15:0] XG_OFFS_USR
-#define MPU6050_RA_XG_OFFS_USRL     0x14
-#define MPU6050_RA_YG_OFFS_USRH     0x15 //[15:0] YG_OFFS_USR
-#define MPU6050_RA_YG_OFFS_USRL     0x16
-#define MPU6050_RA_ZG_OFFS_USRH     0x17 //[15:0] ZG_OFFS_USR
-#define MPU6050_RA_ZG_OFFS_USRL     0x18
-#define MPU6050_RA_SMPLRT_DIV       0x19
-#define MPU6050_RA_CONFIG           0x1A
-#define MPU6050_RA_GYRO_CONFIG      0x1B
-#define MPU6050_RA_ACCEL_CONFIG     0x1C
-#define MPU6050_RA_FF_THR           0x1D
-#define MPU6050_RA_FF_DUR           0x1E
-#define MPU6050_RA_MOT_THR          0x1F
-#define MPU6050_RA_MOT_DUR          0x20
-#define MPU6050_RA_ZRMOT_THR        0x21
-#define MPU6050_RA_ZRMOT_DUR        0x22
-#define MPU6050_RA_FIFO_EN          0x23
-#define MPU6050_RA_I2C_MST_CTRL     0x24
-#define MPU6050_RA_I2C_SLV0_ADDR    0x25
-#define MPU6050_RA_I2C_SLV0_REG     0x26
-#define MPU6050_RA_I2C_SLV0_CTRL    0x27
-#define MPU6050_RA_I2C_SLV1_ADDR    0x28
-#define MPU6050_RA_I2C_SLV1_REG     0x29
-#define MPU6050_RA_I2C_SLV1_CTRL    0x2A
-#define MPU6050_RA_I2C_SLV2_ADDR    0x2B
-#define MPU6050_RA_I2C_SLV2_REG     0x2C
-#define MPU6050_RA_I2C_SLV2_CTRL    0x2D
-#define MPU6050_RA_I2C_SLV3_ADDR    0x2E
-#define MPU6050_RA_I2C_SLV3_REG     0x2F
-#define MPU6050_RA_I2C_SLV3_CTRL    0x30
-#define MPU6050_RA_I2C_SLV4_ADDR    0x31
-#define MPU6050_RA_I2C_SLV4_REG     0x32
-#define MPU6050_RA_I2C_SLV4_DO      0x33
-#define MPU6050_RA_I2C_SLV4_CTRL    0x34
-#define MPU6050_RA_I2C_SLV4_DI      0x35
-#define MPU6050_RA_I2C_MST_STATUS   0x36
-#define MPU6050_RA_INT_PIN_CFG      0x37
-#define MPU6050_RA_INT_ENABLE       0x38
-#define MPU6050_RA_DMP_INT_STATUS   0x39
-#define MPU6050_RA_INT_STATUS       0x3A
-#define MPU6050_RA_ACCEL_XOUT_H     0x3B
-#define MPU6050_RA_ACCEL_XOUT_L     0x3C
-#define MPU6050_RA_ACCEL_YOUT_H     0x3D
-#define MPU6050_RA_ACCEL_YOUT_L     0x3E
-#define MPU6050_RA_ACCEL_ZOUT_H     0x3F
-#define MPU6050_RA_ACCEL_ZOUT_L     0x40
-#define MPU6050_RA_TEMP_OUT_H       0x41
-#define MPU6050_RA_TEMP_OUT_L       0x42
-#define MPU6050_RA_GYRO_XOUT_H      0x43
-#define MPU6050_RA_GYRO_XOUT_L      0x44
-#define MPU6050_RA_GYRO_YOUT_H      0x45
-#define MPU6050_RA_GYRO_YOUT_L      0x46
-#define MPU6050_RA_GYRO_ZOUT_H      0x47
-#define MPU6050_RA_GYRO_ZOUT_L      0x48
+#define MPU6050_RA_XG_OFFS_TC \
+    0x00  //[7] PWR_MODE, [6:1] XG_OFFS_TC, [0] OTP_BNK_VLD
+#define MPU6050_RA_YG_OFFS_TC \
+    0x01  //[7] PWR_MODE, [6:1] YG_OFFS_TC, [0] OTP_BNK_VLD
+#define MPU6050_RA_ZG_OFFS_TC \
+    0x02  //[7] PWR_MODE, [6:1] ZG_OFFS_TC, [0] OTP_BNK_VLD
+#define MPU6050_RA_X_FINE_GAIN 0x03  //[7:0] X_FINE_GAIN
+#define MPU6050_RA_Y_FINE_GAIN 0x04  //[7:0] Y_FINE_GAIN
+#define MPU6050_RA_Z_FINE_GAIN 0x05  //[7:0] Z_FINE_GAIN
+#define MPU6050_RA_XA_OFFS_H 0x06    //[15:0] XA_OFFS
+#define MPU6050_RA_XA_OFFS_L_TC 0x07
+#define MPU6050_RA_YA_OFFS_H 0x08  //[15:0] YA_OFFS
+#define MPU6050_RA_YA_OFFS_L_TC 0x09
+#define MPU6050_RA_ZA_OFFS_H 0x0A  //[15:0] ZA_OFFS
+#define MPU6050_RA_ZA_OFFS_L_TC 0x0B
+#define MPU6050_RA_XG_OFFS_USRH 0x13  //[15:0] XG_OFFS_USR
+#define MPU6050_RA_XG_OFFS_USRL 0x14
+#define MPU6050_RA_YG_OFFS_USRH 0x15  //[15:0] YG_OFFS_USR
+#define MPU6050_RA_YG_OFFS_USRL 0x16
+#define MPU6050_RA_ZG_OFFS_USRH 0x17  //[15:0] ZG_OFFS_USR
+#define MPU6050_RA_ZG_OFFS_USRL 0x18
+#define MPU6050_RA_SMPLRT_DIV 0x19
+#define MPU6050_RA_CONFIG 0x1A
+#define MPU6050_RA_GYRO_CONFIG 0x1B
+#define MPU6050_RA_ACCEL_CONFIG 0x1C
+#define MPU6050_RA_FF_THR 0x1D
+#define MPU6050_RA_FF_DUR 0x1E
+#define MPU6050_RA_MOT_THR 0x1F
+#define MPU6050_RA_MOT_DUR 0x20
+#define MPU6050_RA_ZRMOT_THR 0x21
+#define MPU6050_RA_ZRMOT_DUR 0x22
+#define MPU6050_RA_FIFO_EN 0x23
+#define MPU6050_RA_I2C_MST_CTRL 0x24
+#define MPU6050_RA_I2C_SLV0_ADDR 0x25
+#define MPU6050_RA_I2C_SLV0_REG 0x26
+#define MPU6050_RA_I2C_SLV0_CTRL 0x27
+#define MPU6050_RA_I2C_SLV1_ADDR 0x28
+#define MPU6050_RA_I2C_SLV1_REG 0x29
+#define MPU6050_RA_I2C_SLV1_CTRL 0x2A
+#define MPU6050_RA_I2C_SLV2_ADDR 0x2B
+#define MPU6050_RA_I2C_SLV2_REG 0x2C
+#define MPU6050_RA_I2C_SLV2_CTRL 0x2D
+#define MPU6050_RA_I2C_SLV3_ADDR 0x2E
+#define MPU6050_RA_I2C_SLV3_REG 0x2F
+#define MPU6050_RA_I2C_SLV3_CTRL 0x30
+#define MPU6050_RA_I2C_SLV4_ADDR 0x31
+#define MPU6050_RA_I2C_SLV4_REG 0x32
+#define MPU6050_RA_I2C_SLV4_DO 0x33
+#define MPU6050_RA_I2C_SLV4_CTRL 0x34
+#define MPU6050_RA_I2C_SLV4_DI 0x35
+#define MPU6050_RA_I2C_MST_STATUS 0x36
+#define MPU6050_RA_INT_PIN_CFG 0x37
+#define MPU6050_RA_INT_ENABLE 0x38
+#define MPU6050_RA_DMP_INT_STATUS 0x39
+#define MPU6050_RA_INT_STATUS 0x3A
+#define MPU6050_RA_ACCEL_XOUT_H 0x3B
+#define MPU6050_RA_ACCEL_XOUT_L 0x3C
+#define MPU6050_RA_ACCEL_YOUT_H 0x3D
+#define MPU6050_RA_ACCEL_YOUT_L 0x3E
+#define MPU6050_RA_ACCEL_ZOUT_H 0x3F
+#define MPU6050_RA_ACCEL_ZOUT_L 0x40
+#define MPU6050_RA_TEMP_OUT_H 0x41
+#define MPU6050_RA_TEMP_OUT_L 0x42
+#define MPU6050_RA_GYRO_XOUT_H 0x43
+#define MPU6050_RA_GYRO_XOUT_L 0x44
+#define MPU6050_RA_GYRO_YOUT_H 0x45
+#define MPU6050_RA_GYRO_YOUT_L 0x46
+#define MPU6050_RA_GYRO_ZOUT_H 0x47
+#define MPU6050_RA_GYRO_ZOUT_L 0x48
 #define MPU6050_RA_EXT_SENS_DATA_00 0x49
 #define MPU6050_RA_EXT_SENS_DATA_01 0x4A
 #define MPU6050_RA_EXT_SENS_DATA_02 0x4B
@@ -140,854 +149,885 @@ THE SOFTWARE.
 #define MPU6050_RA_EXT_SENS_DATA_21 0x5E
 #define MPU6050_RA_EXT_SENS_DATA_22 0x5F
 #define MPU6050_RA_EXT_SENS_DATA_23 0x60
-#define MPU6050_RA_MOT_DETECT_STATUS    0x61
-#define MPU6050_RA_I2C_SLV0_DO      0x63
-#define MPU6050_RA_I2C_SLV1_DO      0x64
-#define MPU6050_RA_I2C_SLV2_DO      0x65
-#define MPU6050_RA_I2C_SLV3_DO      0x66
-#define MPU6050_RA_I2C_MST_DELAY_CTRL   0x67
-#define MPU6050_RA_SIGNAL_PATH_RESET    0x68
-#define MPU6050_RA_MOT_DETECT_CTRL      0x69
-#define MPU6050_RA_USER_CTRL        0x6A
-#define MPU6050_RA_PWR_MGMT_1       0x6B
-#define MPU6050_RA_PWR_MGMT_2       0x6C
-#define MPU6050_RA_BANK_SEL         0x6D
-#define MPU6050_RA_MEM_START_ADDR   0x6E
-#define MPU6050_RA_MEM_R_W          0x6F
-#define MPU6050_RA_DMP_CFG_1        0x70
-#define MPU6050_RA_DMP_CFG_2        0x71
-#define MPU6050_RA_FIFO_COUNTH      0x72
-#define MPU6050_RA_FIFO_COUNTL      0x73
-#define MPU6050_RA_FIFO_R_W         0x74
-#define MPU6050_RA_WHO_AM_I         0x75
+#define MPU6050_RA_MOT_DETECT_STATUS 0x61
+#define MPU6050_RA_I2C_SLV0_DO 0x63
+#define MPU6050_RA_I2C_SLV1_DO 0x64
+#define MPU6050_RA_I2C_SLV2_DO 0x65
+#define MPU6050_RA_I2C_SLV3_DO 0x66
+#define MPU6050_RA_I2C_MST_DELAY_CTRL 0x67
+#define MPU6050_RA_SIGNAL_PATH_RESET 0x68
+#define MPU6050_RA_MOT_DETECT_CTRL 0x69
+#define MPU6050_RA_USER_CTRL 0x6A
+#define MPU6050_RA_PWR_MGMT_1 0x6B
+#define MPU6050_RA_PWR_MGMT_2 0x6C
+#define MPU6050_RA_BANK_SEL 0x6D
+#define MPU6050_RA_MEM_START_ADDR 0x6E
+#define MPU6050_RA_MEM_R_W 0x6F
+#define MPU6050_RA_DMP_CFG_1 0x70
+#define MPU6050_RA_DMP_CFG_2 0x71
+#define MPU6050_RA_FIFO_COUNTH 0x72
+#define MPU6050_RA_FIFO_COUNTL 0x73
+#define MPU6050_RA_FIFO_R_W 0x74
+#define MPU6050_RA_WHO_AM_I 0x75
 
-#define MPU6050_TC_PWR_MODE_BIT     7
-#define MPU6050_TC_OFFSET_BIT       6
-#define MPU6050_TC_OFFSET_LENGTH    6
-#define MPU6050_TC_OTP_BNK_VLD_BIT  0
+#define MPU6050_TC_PWR_MODE_BIT 7
+#define MPU6050_TC_OFFSET_BIT 6
+#define MPU6050_TC_OFFSET_LENGTH 6
+#define MPU6050_TC_OTP_BNK_VLD_BIT 0
 
-#define MPU6050_VDDIO_LEVEL_VLOGIC  0
-#define MPU6050_VDDIO_LEVEL_VDD     1
+#define MPU6050_VDDIO_LEVEL_VLOGIC 0
+#define MPU6050_VDDIO_LEVEL_VDD 1
 
-#define MPU6050_CFG_EXT_SYNC_SET_BIT    5
+#define MPU6050_CFG_EXT_SYNC_SET_BIT 5
 #define MPU6050_CFG_EXT_SYNC_SET_LENGTH 3
-#define MPU6050_CFG_DLPF_CFG_BIT    2
+#define MPU6050_CFG_DLPF_CFG_BIT 2
 #define MPU6050_CFG_DLPF_CFG_LENGTH 3
 
-#define MPU6050_EXT_SYNC_DISABLED       0x0
-#define MPU6050_EXT_SYNC_TEMP_OUT_L     0x1
-#define MPU6050_EXT_SYNC_GYRO_XOUT_L    0x2
-#define MPU6050_EXT_SYNC_GYRO_YOUT_L    0x3
-#define MPU6050_EXT_SYNC_GYRO_ZOUT_L    0x4
-#define MPU6050_EXT_SYNC_ACCEL_XOUT_L   0x5
-#define MPU6050_EXT_SYNC_ACCEL_YOUT_L   0x6
-#define MPU6050_EXT_SYNC_ACCEL_ZOUT_L   0x7
+#define MPU6050_EXT_SYNC_DISABLED 0x0
+#define MPU6050_EXT_SYNC_TEMP_OUT_L 0x1
+#define MPU6050_EXT_SYNC_GYRO_XOUT_L 0x2
+#define MPU6050_EXT_SYNC_GYRO_YOUT_L 0x3
+#define MPU6050_EXT_SYNC_GYRO_ZOUT_L 0x4
+#define MPU6050_EXT_SYNC_ACCEL_XOUT_L 0x5
+#define MPU6050_EXT_SYNC_ACCEL_YOUT_L 0x6
+#define MPU6050_EXT_SYNC_ACCEL_ZOUT_L 0x7
 
-#define MPU6050_DLPF_BW_256         0x00
-#define MPU6050_DLPF_BW_188         0x01
-#define MPU6050_DLPF_BW_98          0x02
-#define MPU6050_DLPF_BW_42          0x03
-#define MPU6050_DLPF_BW_20          0x04
-#define MPU6050_DLPF_BW_10          0x05
-#define MPU6050_DLPF_BW_5           0x06
+#define MPU6050_DLPF_BW_256 0x00
+#define MPU6050_DLPF_BW_188 0x01
+#define MPU6050_DLPF_BW_98 0x02
+#define MPU6050_DLPF_BW_42 0x03
+#define MPU6050_DLPF_BW_20 0x04
+#define MPU6050_DLPF_BW_10 0x05
+#define MPU6050_DLPF_BW_5 0x06
 
-#define MPU6050_GCONFIG_FS_SEL_BIT      4
-#define MPU6050_GCONFIG_FS_SEL_LENGTH   2
+#define MPU6050_GCONFIG_FS_SEL_BIT 4
+#define MPU6050_GCONFIG_FS_SEL_LENGTH 2
 
-#define MPU6050_GYRO_FS_250         0x00
-#define MPU6050_GYRO_FS_500         0x01
-#define MPU6050_GYRO_FS_1000        0x02
-#define MPU6050_GYRO_FS_2000        0x03
+#define MPU6050_GYRO_FS_250 0x00
+#define MPU6050_GYRO_FS_500 0x01
+#define MPU6050_GYRO_FS_1000 0x02
+#define MPU6050_GYRO_FS_2000 0x03
 
-#define MPU6050_ACONFIG_XA_ST_BIT           7
-#define MPU6050_ACONFIG_YA_ST_BIT           6
-#define MPU6050_ACONFIG_ZA_ST_BIT           5
-#define MPU6050_ACONFIG_AFS_SEL_BIT         4
-#define MPU6050_ACONFIG_AFS_SEL_LENGTH      2
-#define MPU6050_ACONFIG_ACCEL_HPF_BIT       2
-#define MPU6050_ACONFIG_ACCEL_HPF_LENGTH    3
+#define MPU6050_ACONFIG_XA_ST_BIT 7
+#define MPU6050_ACONFIG_YA_ST_BIT 6
+#define MPU6050_ACONFIG_ZA_ST_BIT 5
+#define MPU6050_ACONFIG_AFS_SEL_BIT 4
+#define MPU6050_ACONFIG_AFS_SEL_LENGTH 2
+#define MPU6050_ACONFIG_ACCEL_HPF_BIT 2
+#define MPU6050_ACONFIG_ACCEL_HPF_LENGTH 3
 
-#define MPU6050_ACCEL_FS_2          0x00
-#define MPU6050_ACCEL_FS_4          0x01
-#define MPU6050_ACCEL_FS_8          0x02
-#define MPU6050_ACCEL_FS_16         0x03
+#define MPU6050_ACCEL_FS_2 0x00
+#define MPU6050_ACCEL_FS_4 0x01
+#define MPU6050_ACCEL_FS_8 0x02
+#define MPU6050_ACCEL_FS_16 0x03
 
-#define MPU6050_DHPF_RESET          0x00
-#define MPU6050_DHPF_5              0x01
-#define MPU6050_DHPF_2P5            0x02
-#define MPU6050_DHPF_1P25           0x03
-#define MPU6050_DHPF_0P63           0x04
-#define MPU6050_DHPF_HOLD           0x07
+#define MPU6050_DHPF_RESET 0x00
+#define MPU6050_DHPF_5 0x01
+#define MPU6050_DHPF_2P5 0x02
+#define MPU6050_DHPF_1P25 0x03
+#define MPU6050_DHPF_0P63 0x04
+#define MPU6050_DHPF_HOLD 0x07
 
-#define MPU6050_TEMP_FIFO_EN_BIT    7
-#define MPU6050_XG_FIFO_EN_BIT      6
-#define MPU6050_YG_FIFO_EN_BIT      5
-#define MPU6050_ZG_FIFO_EN_BIT      4
-#define MPU6050_ACCEL_FIFO_EN_BIT   3
-#define MPU6050_SLV2_FIFO_EN_BIT    2
-#define MPU6050_SLV1_FIFO_EN_BIT    1
-#define MPU6050_SLV0_FIFO_EN_BIT    0
+#define MPU6050_TEMP_FIFO_EN_BIT 7
+#define MPU6050_XG_FIFO_EN_BIT 6
+#define MPU6050_YG_FIFO_EN_BIT 5
+#define MPU6050_ZG_FIFO_EN_BIT 4
+#define MPU6050_ACCEL_FIFO_EN_BIT 3
+#define MPU6050_SLV2_FIFO_EN_BIT 2
+#define MPU6050_SLV1_FIFO_EN_BIT 1
+#define MPU6050_SLV0_FIFO_EN_BIT 0
 
-#define MPU6050_MULT_MST_EN_BIT     7
-#define MPU6050_WAIT_FOR_ES_BIT     6
-#define MPU6050_SLV_3_FIFO_EN_BIT   5
-#define MPU6050_I2C_MST_P_NSR_BIT   4
-#define MPU6050_I2C_MST_CLK_BIT     3
-#define MPU6050_I2C_MST_CLK_LENGTH  4
+#define MPU6050_MULT_MST_EN_BIT 7
+#define MPU6050_WAIT_FOR_ES_BIT 6
+#define MPU6050_SLV_3_FIFO_EN_BIT 5
+#define MPU6050_I2C_MST_P_NSR_BIT 4
+#define MPU6050_I2C_MST_CLK_BIT 3
+#define MPU6050_I2C_MST_CLK_LENGTH 4
 
-#define MPU6050_CLOCK_DIV_348       0x0
-#define MPU6050_CLOCK_DIV_333       0x1
-#define MPU6050_CLOCK_DIV_320       0x2
-#define MPU6050_CLOCK_DIV_308       0x3
-#define MPU6050_CLOCK_DIV_296       0x4
-#define MPU6050_CLOCK_DIV_286       0x5
-#define MPU6050_CLOCK_DIV_276       0x6
-#define MPU6050_CLOCK_DIV_267       0x7
-#define MPU6050_CLOCK_DIV_258       0x8
-#define MPU6050_CLOCK_DIV_500       0x9
-#define MPU6050_CLOCK_DIV_471       0xA
-#define MPU6050_CLOCK_DIV_444       0xB
-#define MPU6050_CLOCK_DIV_421       0xC
-#define MPU6050_CLOCK_DIV_400       0xD
-#define MPU6050_CLOCK_DIV_381       0xE
-#define MPU6050_CLOCK_DIV_364       0xF
+#define MPU6050_CLOCK_DIV_348 0x0
+#define MPU6050_CLOCK_DIV_333 0x1
+#define MPU6050_CLOCK_DIV_320 0x2
+#define MPU6050_CLOCK_DIV_308 0x3
+#define MPU6050_CLOCK_DIV_296 0x4
+#define MPU6050_CLOCK_DIV_286 0x5
+#define MPU6050_CLOCK_DIV_276 0x6
+#define MPU6050_CLOCK_DIV_267 0x7
+#define MPU6050_CLOCK_DIV_258 0x8
+#define MPU6050_CLOCK_DIV_500 0x9
+#define MPU6050_CLOCK_DIV_471 0xA
+#define MPU6050_CLOCK_DIV_444 0xB
+#define MPU6050_CLOCK_DIV_421 0xC
+#define MPU6050_CLOCK_DIV_400 0xD
+#define MPU6050_CLOCK_DIV_381 0xE
+#define MPU6050_CLOCK_DIV_364 0xF
 
-#define MPU6050_I2C_SLV_RW_BIT      7
-#define MPU6050_I2C_SLV_ADDR_BIT    6
+#define MPU6050_I2C_SLV_RW_BIT 7
+#define MPU6050_I2C_SLV_ADDR_BIT 6
 #define MPU6050_I2C_SLV_ADDR_LENGTH 7
-#define MPU6050_I2C_SLV_EN_BIT      7
+#define MPU6050_I2C_SLV_EN_BIT 7
 #define MPU6050_I2C_SLV_BYTE_SW_BIT 6
 #define MPU6050_I2C_SLV_REG_DIS_BIT 5
-#define MPU6050_I2C_SLV_GRP_BIT     4
-#define MPU6050_I2C_SLV_LEN_BIT     3
-#define MPU6050_I2C_SLV_LEN_LENGTH  4
+#define MPU6050_I2C_SLV_GRP_BIT 4
+#define MPU6050_I2C_SLV_LEN_BIT 3
+#define MPU6050_I2C_SLV_LEN_LENGTH 4
 
-#define MPU6050_I2C_SLV4_RW_BIT         7
-#define MPU6050_I2C_SLV4_ADDR_BIT       6
-#define MPU6050_I2C_SLV4_ADDR_LENGTH    7
-#define MPU6050_I2C_SLV4_EN_BIT         7
-#define MPU6050_I2C_SLV4_INT_EN_BIT     6
-#define MPU6050_I2C_SLV4_REG_DIS_BIT    5
-#define MPU6050_I2C_SLV4_MST_DLY_BIT    4
+#define MPU6050_I2C_SLV4_RW_BIT 7
+#define MPU6050_I2C_SLV4_ADDR_BIT 6
+#define MPU6050_I2C_SLV4_ADDR_LENGTH 7
+#define MPU6050_I2C_SLV4_EN_BIT 7
+#define MPU6050_I2C_SLV4_INT_EN_BIT 6
+#define MPU6050_I2C_SLV4_REG_DIS_BIT 5
+#define MPU6050_I2C_SLV4_MST_DLY_BIT 4
 #define MPU6050_I2C_SLV4_MST_DLY_LENGTH 5
 
-#define MPU6050_MST_PASS_THROUGH_BIT    7
-#define MPU6050_MST_I2C_SLV4_DONE_BIT   6
-#define MPU6050_MST_I2C_LOST_ARB_BIT    5
-#define MPU6050_MST_I2C_SLV4_NACK_BIT   4
-#define MPU6050_MST_I2C_SLV3_NACK_BIT   3
-#define MPU6050_MST_I2C_SLV2_NACK_BIT   2
-#define MPU6050_MST_I2C_SLV1_NACK_BIT   1
-#define MPU6050_MST_I2C_SLV0_NACK_BIT   0
+#define MPU6050_MST_PASS_THROUGH_BIT 7
+#define MPU6050_MST_I2C_SLV4_DONE_BIT 6
+#define MPU6050_MST_I2C_LOST_ARB_BIT 5
+#define MPU6050_MST_I2C_SLV4_NACK_BIT 4
+#define MPU6050_MST_I2C_SLV3_NACK_BIT 3
+#define MPU6050_MST_I2C_SLV2_NACK_BIT 2
+#define MPU6050_MST_I2C_SLV1_NACK_BIT 1
+#define MPU6050_MST_I2C_SLV0_NACK_BIT 0
 
-#define MPU6050_INTCFG_INT_LEVEL_BIT        7
-#define MPU6050_INTCFG_INT_OPEN_BIT         6
-#define MPU6050_INTCFG_LATCH_INT_EN_BIT     5
-#define MPU6050_INTCFG_INT_RD_CLEAR_BIT     4
-#define MPU6050_INTCFG_FSYNC_INT_LEVEL_BIT  3
-#define MPU6050_INTCFG_FSYNC_INT_EN_BIT     2
-#define MPU6050_INTCFG_I2C_BYPASS_EN_BIT    1
-#define MPU6050_INTCFG_CLKOUT_EN_BIT        0
+#define MPU6050_INTCFG_INT_LEVEL_BIT 7
+#define MPU6050_INTCFG_INT_OPEN_BIT 6
+#define MPU6050_INTCFG_LATCH_INT_EN_BIT 5
+#define MPU6050_INTCFG_INT_RD_CLEAR_BIT 4
+#define MPU6050_INTCFG_FSYNC_INT_LEVEL_BIT 3
+#define MPU6050_INTCFG_FSYNC_INT_EN_BIT 2
+#define MPU6050_INTCFG_I2C_BYPASS_EN_BIT 1
+#define MPU6050_INTCFG_CLKOUT_EN_BIT 0
 
-#define MPU6050_INTMODE_ACTIVEHIGH  0x00
-#define MPU6050_INTMODE_ACTIVELOW   0x01
+#define MPU6050_INTMODE_ACTIVEHIGH 0x00
+#define MPU6050_INTMODE_ACTIVELOW 0x01
 
-#define MPU6050_INTDRV_PUSHPULL     0x00
-#define MPU6050_INTDRV_OPENDRAIN    0x01
+#define MPU6050_INTDRV_PUSHPULL 0x00
+#define MPU6050_INTDRV_OPENDRAIN 0x01
 
-#define MPU6050_INTLATCH_50USPULSE  0x00
-#define MPU6050_INTLATCH_WAITCLEAR  0x01
+#define MPU6050_INTLATCH_50USPULSE 0x00
+#define MPU6050_INTLATCH_WAITCLEAR 0x01
 
 #define MPU6050_INTCLEAR_STATUSREAD 0x00
-#define MPU6050_INTCLEAR_ANYREAD    0x01
+#define MPU6050_INTCLEAR_ANYREAD 0x01
 
-#define MPU6050_INTERRUPT_FF_BIT            7
-#define MPU6050_INTERRUPT_MOT_BIT           6
-#define MPU6050_INTERRUPT_ZMOT_BIT          5
-#define MPU6050_INTERRUPT_FIFO_OFLOW_BIT    4
-#define MPU6050_INTERRUPT_I2C_MST_INT_BIT   3
-#define MPU6050_INTERRUPT_PLL_RDY_INT_BIT   2
-#define MPU6050_INTERRUPT_DMP_INT_BIT       1
-#define MPU6050_INTERRUPT_DATA_RDY_BIT      0
+#define MPU6050_INTERRUPT_FF_BIT 7
+#define MPU6050_INTERRUPT_MOT_BIT 6
+#define MPU6050_INTERRUPT_ZMOT_BIT 5
+#define MPU6050_INTERRUPT_FIFO_OFLOW_BIT 4
+#define MPU6050_INTERRUPT_I2C_MST_INT_BIT 3
+#define MPU6050_INTERRUPT_PLL_RDY_INT_BIT 2
+#define MPU6050_INTERRUPT_DMP_INT_BIT 1
+#define MPU6050_INTERRUPT_DATA_RDY_BIT 0
 
 // TODO: figure out what these actually do
 // UMPL source code is not very obivous
-#define MPU6050_DMPINT_5_BIT            5
-#define MPU6050_DMPINT_4_BIT            4
-#define MPU6050_DMPINT_3_BIT            3
-#define MPU6050_DMPINT_2_BIT            2
-#define MPU6050_DMPINT_1_BIT            1
-#define MPU6050_DMPINT_0_BIT            0
+#define MPU6050_DMPINT_5_BIT 5
+#define MPU6050_DMPINT_4_BIT 4
+#define MPU6050_DMPINT_3_BIT 3
+#define MPU6050_DMPINT_2_BIT 2
+#define MPU6050_DMPINT_1_BIT 1
+#define MPU6050_DMPINT_0_BIT 0
 
-#define MPU6050_MOTION_MOT_XNEG_BIT     7
-#define MPU6050_MOTION_MOT_XPOS_BIT     6
-#define MPU6050_MOTION_MOT_YNEG_BIT     5
-#define MPU6050_MOTION_MOT_YPOS_BIT     4
-#define MPU6050_MOTION_MOT_ZNEG_BIT     3
-#define MPU6050_MOTION_MOT_ZPOS_BIT     2
-#define MPU6050_MOTION_MOT_ZRMOT_BIT    0
+#define MPU6050_MOTION_MOT_XNEG_BIT 7
+#define MPU6050_MOTION_MOT_XPOS_BIT 6
+#define MPU6050_MOTION_MOT_YNEG_BIT 5
+#define MPU6050_MOTION_MOT_YPOS_BIT 4
+#define MPU6050_MOTION_MOT_ZNEG_BIT 3
+#define MPU6050_MOTION_MOT_ZPOS_BIT 2
+#define MPU6050_MOTION_MOT_ZRMOT_BIT 0
 
-#define MPU6050_DELAYCTRL_DELAY_ES_SHADOW_BIT   7
-#define MPU6050_DELAYCTRL_I2C_SLV4_DLY_EN_BIT   4
-#define MPU6050_DELAYCTRL_I2C_SLV3_DLY_EN_BIT   3
-#define MPU6050_DELAYCTRL_I2C_SLV2_DLY_EN_BIT   2
-#define MPU6050_DELAYCTRL_I2C_SLV1_DLY_EN_BIT   1
-#define MPU6050_DELAYCTRL_I2C_SLV0_DLY_EN_BIT   0
+#define MPU6050_DELAYCTRL_DELAY_ES_SHADOW_BIT 7
+#define MPU6050_DELAYCTRL_I2C_SLV4_DLY_EN_BIT 4
+#define MPU6050_DELAYCTRL_I2C_SLV3_DLY_EN_BIT 3
+#define MPU6050_DELAYCTRL_I2C_SLV2_DLY_EN_BIT 2
+#define MPU6050_DELAYCTRL_I2C_SLV1_DLY_EN_BIT 1
+#define MPU6050_DELAYCTRL_I2C_SLV0_DLY_EN_BIT 0
 
-#define MPU6050_PATHRESET_GYRO_RESET_BIT    2
-#define MPU6050_PATHRESET_ACCEL_RESET_BIT   1
-#define MPU6050_PATHRESET_TEMP_RESET_BIT    0
+#define MPU6050_PATHRESET_GYRO_RESET_BIT 2
+#define MPU6050_PATHRESET_ACCEL_RESET_BIT 1
+#define MPU6050_PATHRESET_TEMP_RESET_BIT 0
 
-#define MPU6050_DETECT_ACCEL_ON_DELAY_BIT       5
-#define MPU6050_DETECT_ACCEL_ON_DELAY_LENGTH    2
-#define MPU6050_DETECT_FF_COUNT_BIT             3
-#define MPU6050_DETECT_FF_COUNT_LENGTH          2
-#define MPU6050_DETECT_MOT_COUNT_BIT            1
-#define MPU6050_DETECT_MOT_COUNT_LENGTH         2
+#define MPU6050_DETECT_ACCEL_ON_DELAY_BIT 5
+#define MPU6050_DETECT_ACCEL_ON_DELAY_LENGTH 2
+#define MPU6050_DETECT_FF_COUNT_BIT 3
+#define MPU6050_DETECT_FF_COUNT_LENGTH 2
+#define MPU6050_DETECT_MOT_COUNT_BIT 1
+#define MPU6050_DETECT_MOT_COUNT_LENGTH 2
 
-#define MPU6050_DETECT_DECREMENT_RESET  0x0
-#define MPU6050_DETECT_DECREMENT_1      0x1
-#define MPU6050_DETECT_DECREMENT_2      0x2
-#define MPU6050_DETECT_DECREMENT_4      0x3
+#define MPU6050_DETECT_DECREMENT_RESET 0x0
+#define MPU6050_DETECT_DECREMENT_1 0x1
+#define MPU6050_DETECT_DECREMENT_2 0x2
+#define MPU6050_DETECT_DECREMENT_4 0x3
 
-#define MPU6050_USERCTRL_DMP_EN_BIT             7
-#define MPU6050_USERCTRL_FIFO_EN_BIT            6
-#define MPU6050_USERCTRL_I2C_MST_EN_BIT         5
-#define MPU6050_USERCTRL_I2C_IF_DIS_BIT         4
-#define MPU6050_USERCTRL_DMP_RESET_BIT          3
-#define MPU6050_USERCTRL_FIFO_RESET_BIT         2
-#define MPU6050_USERCTRL_I2C_MST_RESET_BIT      1
-#define MPU6050_USERCTRL_SIG_COND_RESET_BIT     0
+#define MPU6050_USERCTRL_DMP_EN_BIT 7
+#define MPU6050_USERCTRL_FIFO_EN_BIT 6
+#define MPU6050_USERCTRL_I2C_MST_EN_BIT 5
+#define MPU6050_USERCTRL_I2C_IF_DIS_BIT 4
+#define MPU6050_USERCTRL_DMP_RESET_BIT 3
+#define MPU6050_USERCTRL_FIFO_RESET_BIT 2
+#define MPU6050_USERCTRL_I2C_MST_RESET_BIT 1
+#define MPU6050_USERCTRL_SIG_COND_RESET_BIT 0
 
-#define MPU6050_PWR1_DEVICE_RESET_BIT   7
-#define MPU6050_PWR1_SLEEP_BIT          6
-#define MPU6050_PWR1_CYCLE_BIT          5
-#define MPU6050_PWR1_TEMP_DIS_BIT       3
-#define MPU6050_PWR1_CLKSEL_BIT         2
-#define MPU6050_PWR1_CLKSEL_LENGTH      3
+#define MPU6050_PWR1_DEVICE_RESET_BIT 7
+#define MPU6050_PWR1_SLEEP_BIT 6
+#define MPU6050_PWR1_CYCLE_BIT 5
+#define MPU6050_PWR1_TEMP_DIS_BIT 3
+#define MPU6050_PWR1_CLKSEL_BIT 2
+#define MPU6050_PWR1_CLKSEL_LENGTH 3
 
-#define MPU6050_CLOCK_INTERNAL          0x00
-#define MPU6050_CLOCK_PLL_XGYRO         0x01
-#define MPU6050_CLOCK_PLL_YGYRO         0x02
-#define MPU6050_CLOCK_PLL_ZGYRO         0x03
-#define MPU6050_CLOCK_PLL_EXT32K        0x04
-#define MPU6050_CLOCK_PLL_EXT19M        0x05
-#define MPU6050_CLOCK_KEEP_RESET        0x07
+#define MPU6050_CLOCK_INTERNAL 0x00
+#define MPU6050_CLOCK_PLL_XGYRO 0x01
+#define MPU6050_CLOCK_PLL_YGYRO 0x02
+#define MPU6050_CLOCK_PLL_ZGYRO 0x03
+#define MPU6050_CLOCK_PLL_EXT32K 0x04
+#define MPU6050_CLOCK_PLL_EXT19M 0x05
+#define MPU6050_CLOCK_KEEP_RESET 0x07
 
-#define MPU6050_PWR2_LP_WAKE_CTRL_BIT       7
-#define MPU6050_PWR2_LP_WAKE_CTRL_LENGTH    2
-#define MPU6050_PWR2_STBY_XA_BIT            5
-#define MPU6050_PWR2_STBY_YA_BIT            4
-#define MPU6050_PWR2_STBY_ZA_BIT            3
-#define MPU6050_PWR2_STBY_XG_BIT            2
-#define MPU6050_PWR2_STBY_YG_BIT            1
-#define MPU6050_PWR2_STBY_ZG_BIT            0
+#define MPU6050_PWR2_LP_WAKE_CTRL_BIT 7
+#define MPU6050_PWR2_LP_WAKE_CTRL_LENGTH 2
+#define MPU6050_PWR2_STBY_XA_BIT 5
+#define MPU6050_PWR2_STBY_YA_BIT 4
+#define MPU6050_PWR2_STBY_ZA_BIT 3
+#define MPU6050_PWR2_STBY_XG_BIT 2
+#define MPU6050_PWR2_STBY_YG_BIT 1
+#define MPU6050_PWR2_STBY_ZG_BIT 0
 
-#define MPU6050_WAKE_FREQ_1P25      0x0
-#define MPU6050_WAKE_FREQ_2P5       0x1
-#define MPU6050_WAKE_FREQ_5         0x2
-#define MPU6050_WAKE_FREQ_10        0x3
+#define MPU6050_WAKE_FREQ_1P25 0x0
+#define MPU6050_WAKE_FREQ_2P5 0x1
+#define MPU6050_WAKE_FREQ_5 0x2
+#define MPU6050_WAKE_FREQ_10 0x3
 
-#define MPU6050_BANKSEL_PRFTCH_EN_BIT       6
-#define MPU6050_BANKSEL_CFG_USER_BANK_BIT   5
-#define MPU6050_BANKSEL_MEM_SEL_BIT         4
-#define MPU6050_BANKSEL_MEM_SEL_LENGTH      5
+#define MPU6050_BANKSEL_PRFTCH_EN_BIT 6
+#define MPU6050_BANKSEL_CFG_USER_BANK_BIT 5
+#define MPU6050_BANKSEL_MEM_SEL_BIT 4
+#define MPU6050_BANKSEL_MEM_SEL_LENGTH 5
 
-#define MPU6050_WHO_AM_I_BIT        6
-#define MPU6050_WHO_AM_I_LENGTH     6
+#define MPU6050_WHO_AM_I_BIT 6
+#define MPU6050_WHO_AM_I_LENGTH 6
 
-#define MPU6050_DMP_MEMORY_BANKS        8
-#define MPU6050_DMP_MEMORY_BANK_SIZE    256
-#define MPU6050_DMP_MEMORY_CHUNK_SIZE   16
+#define MPU6050_DMP_MEMORY_BANKS 8
+#define MPU6050_DMP_MEMORY_BANK_SIZE 256
+#define MPU6050_DMP_MEMORY_CHUNK_SIZE 16
 
 // note: DMP code memory blocks defined at end of header file
 
 class MPU6050 {
-    private:
-        I2Cdev *i2Cdev;
-    public:
-        MPU6050(std::shared_ptr<SharedI2C> sharedI2C);
-        MPU6050(std::shared_ptr<SharedI2C> sharedI2C, uint8_t address);
-
-        void initialize();
-        bool testConnection();
-
-        // AUX_VDDIO register
-        uint8_t getAuxVDDIOLevel();
-        void setAuxVDDIOLevel(uint8_t level);
-
-        // SMPLRT_DIV register
-        uint8_t getRate();
-        void setRate(uint8_t rate);
-
-        // CONFIG register
-        uint8_t getExternalFrameSync();
-        void setExternalFrameSync(uint8_t sync);
-        uint8_t getDLPFMode();
-        void setDLPFMode(uint8_t bandwidth);
-
-        // GYRO_CONFIG register
-        uint8_t getFullScaleGyroRange();
-        void setFullScaleGyroRange(uint8_t range);
-
-        // ACCEL_CONFIG register
-        bool getAccelXSelfTest();
-        void setAccelXSelfTest(bool enabled);
-        bool getAccelYSelfTest();
-        void setAccelYSelfTest(bool enabled);
-        bool getAccelZSelfTest();
-        void setAccelZSelfTest(bool enabled);
-        uint8_t getFullScaleAccelRange();
-        void setFullScaleAccelRange(uint8_t range);
-        uint8_t getDHPFMode();
-        void setDHPFMode(uint8_t mode);
-
-        // FF_THR register
-        uint8_t getFreefallDetectionThreshold();
-        void setFreefallDetectionThreshold(uint8_t threshold);
-
-        // FF_DUR register
-        uint8_t getFreefallDetectionDuration();
-        void setFreefallDetectionDuration(uint8_t duration);
-
-        // MOT_THR register
-        uint8_t getMotionDetectionThreshold();
-        void setMotionDetectionThreshold(uint8_t threshold);
-
-        // MOT_DUR register
-        uint8_t getMotionDetectionDuration();
-        void setMotionDetectionDuration(uint8_t duration);
-
-        // ZRMOT_THR register
-        uint8_t getZeroMotionDetectionThreshold();
-        void setZeroMotionDetectionThreshold(uint8_t threshold);
-
-        // ZRMOT_DUR register
-        uint8_t getZeroMotionDetectionDuration();
-        void setZeroMotionDetectionDuration(uint8_t duration);
-
-        // FIFO_EN register
-        bool getTempFIFOEnabled();
-        void setTempFIFOEnabled(bool enabled);
-        bool getXGyroFIFOEnabled();
-        void setXGyroFIFOEnabled(bool enabled);
-        bool getYGyroFIFOEnabled();
-        void setYGyroFIFOEnabled(bool enabled);
-        bool getZGyroFIFOEnabled();
-        void setZGyroFIFOEnabled(bool enabled);
-        bool getAccelFIFOEnabled();
-        void setAccelFIFOEnabled(bool enabled);
-        bool getSlave2FIFOEnabled();
-        void setSlave2FIFOEnabled(bool enabled);
-        bool getSlave1FIFOEnabled();
-        void setSlave1FIFOEnabled(bool enabled);
-        bool getSlave0FIFOEnabled();
-        void setSlave0FIFOEnabled(bool enabled);
-
-        // I2C_MST_CTRL register
-        bool getMultiMasterEnabled();
-        void setMultiMasterEnabled(bool enabled);
-        bool getWaitForExternalSensorEnabled();
-        void setWaitForExternalSensorEnabled(bool enabled);
-        bool getSlave3FIFOEnabled();
-        void setSlave3FIFOEnabled(bool enabled);
-        bool getSlaveReadWriteTransitionEnabled();
-        void setSlaveReadWriteTransitionEnabled(bool enabled);
-        uint8_t getMasterClockSpeed();
-        void setMasterClockSpeed(uint8_t speed);
-
-        // I2C_SLV* registers (Slave 0-3)
-        uint8_t getSlaveAddress(uint8_t num);
-        void setSlaveAddress(uint8_t num, uint8_t address);
-        uint8_t getSlaveRegister(uint8_t num);
-        void setSlaveRegister(uint8_t num, uint8_t reg);
-        bool getSlaveEnabled(uint8_t num);
-        void setSlaveEnabled(uint8_t num, bool enabled);
-        bool getSlaveWordByteSwap(uint8_t num);
-        void setSlaveWordByteSwap(uint8_t num, bool enabled);
-        bool getSlaveWriteMode(uint8_t num);
-        void setSlaveWriteMode(uint8_t num, bool mode);
-        bool getSlaveWordGroupOffset(uint8_t num);
-        void setSlaveWordGroupOffset(uint8_t num, bool enabled);
-        uint8_t getSlaveDataLength(uint8_t num);
-        void setSlaveDataLength(uint8_t num, uint8_t length);
-
-        // I2C_SLV* registers (Slave 4)
-        uint8_t getSlave4Address();
-        void setSlave4Address(uint8_t address);
-        uint8_t getSlave4Register();
-        void setSlave4Register(uint8_t reg);
-        void setSlave4OutputByte(uint8_t data);
-        bool getSlave4Enabled();
-        void setSlave4Enabled(bool enabled);
-        bool getSlave4InterruptEnabled();
-        void setSlave4InterruptEnabled(bool enabled);
-        bool getSlave4WriteMode();
-        void setSlave4WriteMode(bool mode);
-        uint8_t getSlave4MasterDelay();
-        void setSlave4MasterDelay(uint8_t delay);
-        uint8_t getSlate4InputByte();
-
-        // I2C_MST_STATUS register
-        bool getPassthroughStatus();
-        bool getSlave4IsDone();
-        bool getLostArbitration();
-        bool getSlave4Nack();
-        bool getSlave3Nack();
-        bool getSlave2Nack();
-        bool getSlave1Nack();
-        bool getSlave0Nack();
-
-        // INT_PIN_CFG register
-        bool getInterruptMode();
-        void setInterruptMode(bool mode);
-        bool getInterruptDrive();
-        void setInterruptDrive(bool drive);
-        bool getInterruptLatch();
-        void setInterruptLatch(bool latch);
-        bool getInterruptLatchClear();
-        void setInterruptLatchClear(bool clear);
-        bool getFSyncInterruptLevel();
-        void setFSyncInterruptLevel(bool level);
-        bool getFSyncInterruptEnabled();
-        void setFSyncInterruptEnabled(bool enabled);
-        bool getI2CBypassEnabled();
-        void setI2CBypassEnabled(bool enabled);
-        bool getClockOutputEnabled();
-        void setClockOutputEnabled(bool enabled);
-
-        // INT_ENABLE register
-        uint8_t getIntEnabled();
-        void setIntEnabled(uint8_t enabled);
-        bool getIntFreefallEnabled();
-        void setIntFreefallEnabled(bool enabled);
-        bool getIntMotionEnabled();
-        void setIntMotionEnabled(bool enabled);
-        bool getIntZeroMotionEnabled();
-        void setIntZeroMotionEnabled(bool enabled);
-        bool getIntFIFOBufferOverflowEnabled();
-        void setIntFIFOBufferOverflowEnabled(bool enabled);
-        bool getIntI2CMasterEnabled();
-        void setIntI2CMasterEnabled(bool enabled);
-        bool getIntDataReadyEnabled();
-        void setIntDataReadyEnabled(bool enabled);
-
-        // INT_STATUS register
-        uint8_t getIntStatus();
-        bool getIntFreefallStatus();
-        bool getIntMotionStatus();
-        bool getIntZeroMotionStatus();
-        bool getIntFIFOBufferOverflowStatus();
-        bool getIntI2CMasterStatus();
-        bool getIntDataReadyStatus();
-
-        // ACCEL_*OUT_* registers
-        void getMotion9(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx, int16_t* gy, int16_t* gz, int16_t* mx, int16_t* my, int16_t* mz);
-        void getMotion6(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx, int16_t* gy, int16_t* gz);
-        void getAcceleration(int16_t* x, int16_t* y, int16_t* z);
-        int16_t getAccelerationX();
-        int16_t getAccelerationY();
-        int16_t getAccelerationZ();
-
-        // TEMP_OUT_* registers
-        int16_t getTemperature();
-
-        // GYRO_*OUT_* registers
-        void getRotation(int16_t* x, int16_t* y, int16_t* z);
-        int16_t getRotationX();
-        int16_t getRotationY();
-        int16_t getRotationZ();
-
-        // EXT_SENS_DATA_* registers
-        uint8_t getExternalSensorByte(int position);
-        uint16_t getExternalSensorWord(int position);
-        uint32_t getExternalSensorDWord(int position);
-
-        // MOT_DETECT_STATUS register
-        bool getXNegMotionDetected();
-        bool getXPosMotionDetected();
-        bool getYNegMotionDetected();
-        bool getYPosMotionDetected();
-        bool getZNegMotionDetected();
-        bool getZPosMotionDetected();
-        bool getZeroMotionDetected();
-
-        // I2C_SLV*_DO register
-        void setSlaveOutputByte(uint8_t num, uint8_t data);
-
-        // I2C_MST_DELAY_CTRL register
-        bool getExternalShadowDelayEnabled();
-        void setExternalShadowDelayEnabled(bool enabled);
-        bool getSlaveDelayEnabled(uint8_t num);
-        void setSlaveDelayEnabled(uint8_t num, bool enabled);
-
-        // SIGNAL_PATH_RESET register
-        void resetGyroscopePath();
-        void resetAccelerometerPath();
-        void resetTemperaturePath();
-
-        // MOT_DETECT_CTRL register
-        uint8_t getAccelerometerPowerOnDelay();
-        void setAccelerometerPowerOnDelay(uint8_t delay);
-        uint8_t getFreefallDetectionCounterDecrement();
-        void setFreefallDetectionCounterDecrement(uint8_t decrement);
-        uint8_t getMotionDetectionCounterDecrement();
-        void setMotionDetectionCounterDecrement(uint8_t decrement);
-
-        // USER_CTRL register
-        bool getFIFOEnabled();
-        void setFIFOEnabled(bool enabled);
-        bool getI2CMasterModeEnabled();
-        void setI2CMasterModeEnabled(bool enabled);
-        void switchSPIEnabled(bool enabled);
-        void resetFIFO();
-        void resetI2CMaster();
-        void resetSensors();
-
-        // PWR_MGMT_1 register
-        void reset();
-        bool getSleepEnabled();
-        void setSleepEnabled(bool enabled);
-        bool getWakeCycleEnabled();
-        void setWakeCycleEnabled(bool enabled);
-        bool getTempSensorEnabled();
-        void setTempSensorEnabled(bool enabled);
-        uint8_t getClockSource();
-        void setClockSource(uint8_t source);
-
-        // PWR_MGMT_2 register
-        uint8_t getWakeFrequency();
-        void setWakeFrequency(uint8_t frequency);
-        bool getStandbyXAccelEnabled();
-        void setStandbyXAccelEnabled(bool enabled);
-        bool getStandbyYAccelEnabled();
-        void setStandbyYAccelEnabled(bool enabled);
-        bool getStandbyZAccelEnabled();
-        void setStandbyZAccelEnabled(bool enabled);
-        bool getStandbyXGyroEnabled();
-        void setStandbyXGyroEnabled(bool enabled);
-        bool getStandbyYGyroEnabled();
-        void setStandbyYGyroEnabled(bool enabled);
-        bool getStandbyZGyroEnabled();
-        void setStandbyZGyroEnabled(bool enabled);
-
-        // FIFO_COUNT_* registers
-        uint16_t getFIFOCount();
-
-        // FIFO_R_W register
-        uint8_t getFIFOByte();
-        void setFIFOByte(uint8_t data);
-        void getFIFOBytes(uint8_t *data, uint8_t length);
-
-        // WHO_AM_I register
-        uint8_t getDeviceID();
-        void setDeviceID(uint8_t id);
-        
-        // ======== UNDOCUMENTED/DMP REGISTERS/METHODS ========
-        
-        // XG_OFFS_TC register
-        uint8_t getOTPBankValid();
-        void setOTPBankValid(bool enabled);
-        int8_t getXGyroOffsetTC();
-        void setXGyroOffsetTC(int8_t offset);
-
-        // YG_OFFS_TC register
-        int8_t getYGyroOffsetTC();
-        void setYGyroOffsetTC(int8_t offset);
-
-        // ZG_OFFS_TC register
-        int8_t getZGyroOffsetTC();
-        void setZGyroOffsetTC(int8_t offset);
-
-        // X_FINE_GAIN register
-        int8_t getXFineGain();
-        void setXFineGain(int8_t gain);
-
-        // Y_FINE_GAIN register
-        int8_t getYFineGain();
-        void setYFineGain(int8_t gain);
-
-        // Z_FINE_GAIN register
-        int8_t getZFineGain();
-        void setZFineGain(int8_t gain);
-
-        // XA_OFFS_* registers
-        int16_t getXAccelOffset();
-        void setXAccelOffset(int16_t offset);
-
-        // YA_OFFS_* register
-        int16_t getYAccelOffset();
-        void setYAccelOffset(int16_t offset);
-
-        // ZA_OFFS_* register
-        int16_t getZAccelOffset();
-        void setZAccelOffset(int16_t offset);
-
-        // XG_OFFS_USR* registers
-        int16_t getXGyroOffset();
-        void setXGyroOffset(int16_t offset);
-
-        // YG_OFFS_USR* register
-        int16_t getYGyroOffset();
-        void setYGyroOffset(int16_t offset);
-
-        // ZG_OFFS_USR* register
-        int16_t getZGyroOffset();
-        void setZGyroOffset(int16_t offset);
-        
-        // INT_ENABLE register (DMP functions)
-        bool getIntPLLReadyEnabled();
-        void setIntPLLReadyEnabled(bool enabled);
-        bool getIntDMPEnabled();
-        void setIntDMPEnabled(bool enabled);
-        
-        // DMP_INT_STATUS
-        bool getDMPInt5Status();
-        bool getDMPInt4Status();
-        bool getDMPInt3Status();
-        bool getDMPInt2Status();
-        bool getDMPInt1Status();
-        bool getDMPInt0Status();
-
-        // INT_STATUS register (DMP functions)
-        bool getIntPLLReadyStatus();
-        bool getIntDMPStatus();
-        
-        // USER_CTRL register (DMP functions)
-        bool getDMPEnabled();
-        void setDMPEnabled(bool enabled);
-        void resetDMP();
-        
-        // BANK_SEL register
-        void setMemoryBank(uint8_t bank, bool prefetchEnabled=false, bool userBank=false);
-        
-        // MEM_START_ADDR register
-        void setMemoryStartAddress(uint8_t address);
-        
-        // MEM_R_W register
-        uint8_t readMemoryByte();
-        void writeMemoryByte(uint8_t data);
-        void readMemoryBlock(uint8_t *data, uint16_t dataSize, uint8_t bank=0, uint8_t address=0);
-        bool writeMemoryBlock(const uint8_t *data, uint16_t dataSize, uint8_t bank=0, uint8_t address=0, bool verify=true, bool useProgMem=false);
-        bool writeProgMemoryBlock(const uint8_t *data, uint16_t dataSize, uint8_t bank=0, uint8_t address=0, bool verify=true);
-
-        bool writeDMPConfigurationSet(const uint8_t *data, uint16_t dataSize, bool useProgMem=false);
-        bool writeProgDMPConfigurationSet(const uint8_t *data, uint16_t dataSize);
-
-        // DMP_CFG_1 register
-        uint8_t getDMPConfig1();
-        void setDMPConfig1(uint8_t config);
-
-        // DMP_CFG_2 register
-        uint8_t getDMPConfig2();
-        void setDMPConfig2(uint8_t config);
-
-        // special methods for MotionApps 2.0 implementation
-        #ifdef MPU6050_INCLUDE_DMP_MOTIONAPPS20
-            uint8_t *dmpPacketBuffer;
-            uint16_t dmpPacketSize;
-
-            uint8_t dmpInitialize();
-            bool dmpPacketAvailable();
-
-            uint8_t dmpSetFIFORate(uint8_t fifoRate);
-            uint8_t dmpGetFIFORate();
-            uint8_t dmpGetSampleStepSizeMS();
-            uint8_t dmpGetSampleFrequency();
-            int32_t dmpDecodeTemperature(int8_t tempReg);
-            
-            // Register callbacks after a packet of FIFO data is processed
-            //uint8_t dmpRegisterFIFORateProcess(inv_obj_func func, int16_t priority);
-            //uint8_t dmpUnregisterFIFORateProcess(inv_obj_func func);
-            uint8_t dmpRunFIFORateProcesses();
-            
-            // Setup FIFO for various output
-            uint8_t dmpSendQuaternion(uint_fast16_t accuracy);
-            uint8_t dmpSendGyro(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendAccel(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendLinearAccel(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendLinearAccelInWorld(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendControlData(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendSensorData(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendExternalSensorData(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendGravity(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendPacketNumber(uint_fast16_t accuracy);
-            uint8_t dmpSendQuantizedAccel(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendEIS(uint_fast16_t elements, uint_fast16_t accuracy);
-
-            // Get Fixed Point data from FIFO
-            uint8_t dmpGetAccel(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetAccel(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetAccel(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetQuaternion(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetQuaternion(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetQuaternion(Quaternion *q, const uint8_t* packet=0);
-            uint8_t dmpGet6AxisQuaternion(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGet6AxisQuaternion(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGet6AxisQuaternion(Quaternion *q, const uint8_t* packet=0);
-            uint8_t dmpGetRelativeQuaternion(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetRelativeQuaternion(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetRelativeQuaternion(Quaternion *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyro(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyro(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyro(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpSetLinearAccelFilterCoefficient(float coef);
-            uint8_t dmpGetLinearAccel(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetLinearAccel(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetLinearAccel(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetLinearAccel(VectorInt16 *v, VectorInt16 *vRaw, VectorFloat *gravity);
-            uint8_t dmpGetLinearAccelInWorld(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetLinearAccelInWorld(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetLinearAccelInWorld(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetLinearAccelInWorld(VectorInt16 *v, VectorInt16 *vReal, Quaternion *q);
-            uint8_t dmpGetGyroAndAccelSensor(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyroAndAccelSensor(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyroAndAccelSensor(VectorInt16 *g, VectorInt16 *a, const uint8_t* packet=0);
-            uint8_t dmpGetGyroSensor(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyroSensor(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyroSensor(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetControlData(int32_t *data, const uint8_t* packet=0);
-            uint8_t dm  pGetTemperature(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGravity(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGravity(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGravity(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetGravity(VectorFloat *v, Quaternion *q);
-            uint8_t dmpGetUnquantizedAccel(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetUnquantizedAccel(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetUnquantizedAccel(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetQuantizedAccel(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetQuantizedAccel(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetQuantizedAccel(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetExternalSensorData(int32_t *data, uint16_t size, const uint8_t* packet=0);
-            uint8_t dmpGetEIS(int32_t *data, const uint8_t* packet=0);
-            
-            uint8_t dmpGetEuler(float *data, Quaternion *q);
-            uint8_t dmpGetYawPitchRoll(float *data, Quaternion *q, VectorFloat *gravity);
-
-            // Get Floating Point data from FIFO
-            uint8_t dmpGetAccelFloat(float *data, const uint8_t* packet=0);
-            uint8_t dmpGetQuaternionFloat(float *data, const uint8_t* packet=0);
-
-            uint8_t dmpProcessFIFOPacket(const unsigned char *dmpData);
-            uint8_t dmpReadAndProcessFIFOPacket(uint8_t numPackets, uint8_t *processed=NULL);
-
-            uint8_t dmpSetFIFOProcessedCallback(void (*func) (void));
-
-            uint8_t dmpInitFIFOParam();
-            uint8_t dmpCloseFIFO();
-            uint8_t dmpSetGyroDataSource(uint8_t source);
-            uint8_t dmpDecodeQuantizedAccel();
-            uint32_t dmpGetGyroSumOfSquare();
-            uint32_t dmpGetAccelSumOfSquare();
-            void dmpOverrideQuaternion(long *q);
-            uint16_t dmpGetFIFOPacketSize();
-        #endif
-
-        // special methods for MotionApps 4.1 implementation
-        #ifdef MPU6050_INCLUDE_DMP_MOTIONAPPS41
-            uint8_t *dmpPacketBuffer;
-            uint16_t dmpPacketSize;
-
-            uint8_t dmpInitialize();
-            bool dmpPacketAvailable();
-
-            uint8_t dmpSetFIFORate(uint8_t fifoRate);
-            uint8_t dmpGetFIFORate();
-            uint8_t dmpGetSampleStepSizeMS();
-            uint8_t dmpGetSampleFrequency();
-            int32_t dmpDecodeTemperature(int8_t tempReg);
-            
-            // Register callbacks after a packet of FIFO data is processed
-            //uint8_t dmpRegisterFIFORateProcess(inv_obj_func func, int16_t priority);
-            //uint8_t dmpUnregisterFIFORateProcess(inv_obj_func func);
-            uint8_t dmpRunFIFORateProcesses();
-            
-            // Setup FIFO for various output
-            uint8_t dmpSendQuaternion(uint_fast16_t accuracy);
-            uint8_t dmpSendGyro(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendAccel(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendLinearAccel(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendLinearAccelInWorld(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendControlData(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendSensorData(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendExternalSensorData(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendGravity(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendPacketNumber(uint_fast16_t accuracy);
-            uint8_t dmpSendQuantizedAccel(uint_fast16_t elements, uint_fast16_t accuracy);
-            uint8_t dmpSendEIS(uint_fast16_t elements, uint_fast16_t accuracy);
-
-            // Get Fixed Point data from FIFO
-            uint8_t dmpGetAccel(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetAccel(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetAccel(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetQuaternion(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetQuaternion(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetQuaternion(Quaternion *q, const uint8_t* packet=0);
-            uint8_t dmpGet6AxisQuaternion(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGet6AxisQuaternion(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGet6AxisQuaternion(Quaternion *q, const uint8_t* packet=0);
-            uint8_t dmpGetRelativeQuaternion(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetRelativeQuaternion(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetRelativeQuaternion(Quaternion *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyro(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyro(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyro(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetMag(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpSetLinearAccelFilterCoefficient(float coef);
-            uint8_t dmpGetLinearAccel(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetLinearAccel(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetLinearAccel(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetLinearAccel(VectorInt16 *v, VectorInt16 *vRaw, VectorFloat *gravity);
-            uint8_t dmpGetLinearAccelInWorld(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetLinearAccelInWorld(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetLinearAccelInWorld(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetLinearAccelInWorld(VectorInt16 *v, VectorInt16 *vReal, Quaternion *q);
-            uint8_t dmpGetGyroAndAccelSensor(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyroAndAccelSensor(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyroAndAccelSensor(VectorInt16 *g, VectorInt16 *a, const uint8_t* packet=0);
-            uint8_t dmpGetGyroSensor(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyroSensor(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGyroSensor(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetControlData(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetTemperature(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGravity(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGravity(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetGravity(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetGravity(VectorFloat *v, Quaternion *q);
-            uint8_t dmpGetUnquantizedAccel(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetUnquantizedAccel(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetUnquantizedAccel(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetQuantizedAccel(int32_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetQuantizedAccel(int16_t *data, const uint8_t* packet=0);
-            uint8_t dmpGetQuantizedAccel(VectorInt16 *v, const uint8_t* packet=0);
-            uint8_t dmpGetExternalSensorData(int32_t *data, uint16_t size, const uint8_t* packet=0);
-            uint8_t dmpGetEIS(int32_t *data, const uint8_t* packet=0);
-            
-            uint8_t dmpGetEuler(float *data, Quaternion *q);
-            uint8_t dmpGetYawPitchRoll(float *data, Quaternion *q, VectorFloat *gravity);
-
-            // Get Floating Point data from FIFO
-            uint8_t dmpGetAccelFloat(float *data, const uint8_t* packet=0);
-            uint8_t dmpGetQuaternionFloat(float *data, const uint8_t* packet=0);
-
-            uint8_t dmpProcessFIFOPacket(const unsigned char *dmpData);
-            uint8_t dmpReadAndProcessFIFOPacket(uint8_t numPackets, uint8_t *processed=NULL);
-
-            uint8_t dmpSetFIFOProcessedCallback(void (*func) (void));
-
-            uint8_t dmpInitFIFOParam();
-            uint8_t dmpCloseFIFO();
-            uint8_t dmpSetGyroDataSource(uint8_t source);
-            uint8_t dmpDecodeQuantizedAccel();
-            uint32_t dmpGetGyroSumOfSquare();
-            uint32_t dmpGetAccelSumOfSquare();
-            void dmpOverrideQuaternion(long *q);
-            uint16_t dmpGetFIFOPacketSize();
-        #endif
-
-    private:
-        uint8_t devAddr;
-        uint8_t buffer[14];
+private:
+    I2Cdev* i2Cdev;
+
+public:
+    MPU6050(std::shared_ptr<SharedI2C> sharedI2C);
+    MPU6050(std::shared_ptr<SharedI2C> sharedI2C, uint8_t address);
+
+    void initialize();
+    bool testConnection();
+
+    // AUX_VDDIO register
+    uint8_t getAuxVDDIOLevel();
+    void setAuxVDDIOLevel(uint8_t level);
+
+    // SMPLRT_DIV register
+    uint8_t getRate();
+    void setRate(uint8_t rate);
+
+    // CONFIG register
+    uint8_t getExternalFrameSync();
+    void setExternalFrameSync(uint8_t sync);
+    uint8_t getDLPFMode();
+    void setDLPFMode(uint8_t bandwidth);
+
+    // GYRO_CONFIG register
+    uint8_t getFullScaleGyroRange();
+    void setFullScaleGyroRange(uint8_t range);
+
+    // ACCEL_CONFIG register
+    bool getAccelXSelfTest();
+    void setAccelXSelfTest(bool enabled);
+    bool getAccelYSelfTest();
+    void setAccelYSelfTest(bool enabled);
+    bool getAccelZSelfTest();
+    void setAccelZSelfTest(bool enabled);
+    uint8_t getFullScaleAccelRange();
+    void setFullScaleAccelRange(uint8_t range);
+    uint8_t getDHPFMode();
+    void setDHPFMode(uint8_t mode);
+
+    // FF_THR register
+    uint8_t getFreefallDetectionThreshold();
+    void setFreefallDetectionThreshold(uint8_t threshold);
+
+    // FF_DUR register
+    uint8_t getFreefallDetectionDuration();
+    void setFreefallDetectionDuration(uint8_t duration);
+
+    // MOT_THR register
+    uint8_t getMotionDetectionThreshold();
+    void setMotionDetectionThreshold(uint8_t threshold);
+
+    // MOT_DUR register
+    uint8_t getMotionDetectionDuration();
+    void setMotionDetectionDuration(uint8_t duration);
+
+    // ZRMOT_THR register
+    uint8_t getZeroMotionDetectionThreshold();
+    void setZeroMotionDetectionThreshold(uint8_t threshold);
+
+    // ZRMOT_DUR register
+    uint8_t getZeroMotionDetectionDuration();
+    void setZeroMotionDetectionDuration(uint8_t duration);
+
+    // FIFO_EN register
+    bool getTempFIFOEnabled();
+    void setTempFIFOEnabled(bool enabled);
+    bool getXGyroFIFOEnabled();
+    void setXGyroFIFOEnabled(bool enabled);
+    bool getYGyroFIFOEnabled();
+    void setYGyroFIFOEnabled(bool enabled);
+    bool getZGyroFIFOEnabled();
+    void setZGyroFIFOEnabled(bool enabled);
+    bool getAccelFIFOEnabled();
+    void setAccelFIFOEnabled(bool enabled);
+    bool getSlave2FIFOEnabled();
+    void setSlave2FIFOEnabled(bool enabled);
+    bool getSlave1FIFOEnabled();
+    void setSlave1FIFOEnabled(bool enabled);
+    bool getSlave0FIFOEnabled();
+    void setSlave0FIFOEnabled(bool enabled);
+
+    // I2C_MST_CTRL register
+    bool getMultiMasterEnabled();
+    void setMultiMasterEnabled(bool enabled);
+    bool getWaitForExternalSensorEnabled();
+    void setWaitForExternalSensorEnabled(bool enabled);
+    bool getSlave3FIFOEnabled();
+    void setSlave3FIFOEnabled(bool enabled);
+    bool getSlaveReadWriteTransitionEnabled();
+    void setSlaveReadWriteTransitionEnabled(bool enabled);
+    uint8_t getMasterClockSpeed();
+    void setMasterClockSpeed(uint8_t speed);
+
+    // I2C_SLV* registers (Slave 0-3)
+    uint8_t getSlaveAddress(uint8_t num);
+    void setSlaveAddress(uint8_t num, uint8_t address);
+    uint8_t getSlaveRegister(uint8_t num);
+    void setSlaveRegister(uint8_t num, uint8_t reg);
+    bool getSlaveEnabled(uint8_t num);
+    void setSlaveEnabled(uint8_t num, bool enabled);
+    bool getSlaveWordByteSwap(uint8_t num);
+    void setSlaveWordByteSwap(uint8_t num, bool enabled);
+    bool getSlaveWriteMode(uint8_t num);
+    void setSlaveWriteMode(uint8_t num, bool mode);
+    bool getSlaveWordGroupOffset(uint8_t num);
+    void setSlaveWordGroupOffset(uint8_t num, bool enabled);
+    uint8_t getSlaveDataLength(uint8_t num);
+    void setSlaveDataLength(uint8_t num, uint8_t length);
+
+    // I2C_SLV* registers (Slave 4)
+    uint8_t getSlave4Address();
+    void setSlave4Address(uint8_t address);
+    uint8_t getSlave4Register();
+    void setSlave4Register(uint8_t reg);
+    void setSlave4OutputByte(uint8_t data);
+    bool getSlave4Enabled();
+    void setSlave4Enabled(bool enabled);
+    bool getSlave4InterruptEnabled();
+    void setSlave4InterruptEnabled(bool enabled);
+    bool getSlave4WriteMode();
+    void setSlave4WriteMode(bool mode);
+    uint8_t getSlave4MasterDelay();
+    void setSlave4MasterDelay(uint8_t delay);
+    uint8_t getSlate4InputByte();
+
+    // I2C_MST_STATUS register
+    bool getPassthroughStatus();
+    bool getSlave4IsDone();
+    bool getLostArbitration();
+    bool getSlave4Nack();
+    bool getSlave3Nack();
+    bool getSlave2Nack();
+    bool getSlave1Nack();
+    bool getSlave0Nack();
+
+    // INT_PIN_CFG register
+    bool getInterruptMode();
+    void setInterruptMode(bool mode);
+    bool getInterruptDrive();
+    void setInterruptDrive(bool drive);
+    bool getInterruptLatch();
+    void setInterruptLatch(bool latch);
+    bool getInterruptLatchClear();
+    void setInterruptLatchClear(bool clear);
+    bool getFSyncInterruptLevel();
+    void setFSyncInterruptLevel(bool level);
+    bool getFSyncInterruptEnabled();
+    void setFSyncInterruptEnabled(bool enabled);
+    bool getI2CBypassEnabled();
+    void setI2CBypassEnabled(bool enabled);
+    bool getClockOutputEnabled();
+    void setClockOutputEnabled(bool enabled);
+
+    // INT_ENABLE register
+    uint8_t getIntEnabled();
+    void setIntEnabled(uint8_t enabled);
+    bool getIntFreefallEnabled();
+    void setIntFreefallEnabled(bool enabled);
+    bool getIntMotionEnabled();
+    void setIntMotionEnabled(bool enabled);
+    bool getIntZeroMotionEnabled();
+    void setIntZeroMotionEnabled(bool enabled);
+    bool getIntFIFOBufferOverflowEnabled();
+    void setIntFIFOBufferOverflowEnabled(bool enabled);
+    bool getIntI2CMasterEnabled();
+    void setIntI2CMasterEnabled(bool enabled);
+    bool getIntDataReadyEnabled();
+    void setIntDataReadyEnabled(bool enabled);
+
+    // INT_STATUS register
+    uint8_t getIntStatus();
+    bool getIntFreefallStatus();
+    bool getIntMotionStatus();
+    bool getIntZeroMotionStatus();
+    bool getIntFIFOBufferOverflowStatus();
+    bool getIntI2CMasterStatus();
+    bool getIntDataReadyStatus();
+
+    // ACCEL_*OUT_* registers
+    void getMotion9(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx,
+                    int16_t* gy, int16_t* gz, int16_t* mx, int16_t* my,
+                    int16_t* mz);
+    void getMotion6(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx,
+                    int16_t* gy, int16_t* gz);
+    void getAcceleration(int16_t* x, int16_t* y, int16_t* z);
+    int16_t getAccelerationX();
+    int16_t getAccelerationY();
+    int16_t getAccelerationZ();
+
+    // TEMP_OUT_* registers
+    int16_t getTemperature();
+
+    // GYRO_*OUT_* registers
+    void getRotation(int16_t* x, int16_t* y, int16_t* z);
+    int16_t getRotationX();
+    int16_t getRotationY();
+    int16_t getRotationZ();
+
+    // EXT_SENS_DATA_* registers
+    uint8_t getExternalSensorByte(int position);
+    uint16_t getExternalSensorWord(int position);
+    uint32_t getExternalSensorDWord(int position);
+
+    // MOT_DETECT_STATUS register
+    bool getXNegMotionDetected();
+    bool getXPosMotionDetected();
+    bool getYNegMotionDetected();
+    bool getYPosMotionDetected();
+    bool getZNegMotionDetected();
+    bool getZPosMotionDetected();
+    bool getZeroMotionDetected();
+
+    // I2C_SLV*_DO register
+    void setSlaveOutputByte(uint8_t num, uint8_t data);
+
+    // I2C_MST_DELAY_CTRL register
+    bool getExternalShadowDelayEnabled();
+    void setExternalShadowDelayEnabled(bool enabled);
+    bool getSlaveDelayEnabled(uint8_t num);
+    void setSlaveDelayEnabled(uint8_t num, bool enabled);
+
+    // SIGNAL_PATH_RESET register
+    void resetGyroscopePath();
+    void resetAccelerometerPath();
+    void resetTemperaturePath();
+
+    // MOT_DETECT_CTRL register
+    uint8_t getAccelerometerPowerOnDelay();
+    void setAccelerometerPowerOnDelay(uint8_t delay);
+    uint8_t getFreefallDetectionCounterDecrement();
+    void setFreefallDetectionCounterDecrement(uint8_t decrement);
+    uint8_t getMotionDetectionCounterDecrement();
+    void setMotionDetectionCounterDecrement(uint8_t decrement);
+
+    // USER_CTRL register
+    bool getFIFOEnabled();
+    void setFIFOEnabled(bool enabled);
+    bool getI2CMasterModeEnabled();
+    void setI2CMasterModeEnabled(bool enabled);
+    void switchSPIEnabled(bool enabled);
+    void resetFIFO();
+    void resetI2CMaster();
+    void resetSensors();
+
+    // PWR_MGMT_1 register
+    void reset();
+    bool getSleepEnabled();
+    void setSleepEnabled(bool enabled);
+    bool getWakeCycleEnabled();
+    void setWakeCycleEnabled(bool enabled);
+    bool getTempSensorEnabled();
+    void setTempSensorEnabled(bool enabled);
+    uint8_t getClockSource();
+    void setClockSource(uint8_t source);
+
+    // PWR_MGMT_2 register
+    uint8_t getWakeFrequency();
+    void setWakeFrequency(uint8_t frequency);
+    bool getStandbyXAccelEnabled();
+    void setStandbyXAccelEnabled(bool enabled);
+    bool getStandbyYAccelEnabled();
+    void setStandbyYAccelEnabled(bool enabled);
+    bool getStandbyZAccelEnabled();
+    void setStandbyZAccelEnabled(bool enabled);
+    bool getStandbyXGyroEnabled();
+    void setStandbyXGyroEnabled(bool enabled);
+    bool getStandbyYGyroEnabled();
+    void setStandbyYGyroEnabled(bool enabled);
+    bool getStandbyZGyroEnabled();
+    void setStandbyZGyroEnabled(bool enabled);
+
+    // FIFO_COUNT_* registers
+    uint16_t getFIFOCount();
+
+    // FIFO_R_W register
+    uint8_t getFIFOByte();
+    void setFIFOByte(uint8_t data);
+    void getFIFOBytes(uint8_t* data, uint8_t length);
+
+    // WHO_AM_I register
+    uint8_t getDeviceID();
+    void setDeviceID(uint8_t id);
+
+    // ======== UNDOCUMENTED/DMP REGISTERS/METHODS ========
+
+    // XG_OFFS_TC register
+    uint8_t getOTPBankValid();
+    void setOTPBankValid(bool enabled);
+    int8_t getXGyroOffsetTC();
+    void setXGyroOffsetTC(int8_t offset);
+
+    // YG_OFFS_TC register
+    int8_t getYGyroOffsetTC();
+    void setYGyroOffsetTC(int8_t offset);
+
+    // ZG_OFFS_TC register
+    int8_t getZGyroOffsetTC();
+    void setZGyroOffsetTC(int8_t offset);
+
+    // X_FINE_GAIN register
+    int8_t getXFineGain();
+    void setXFineGain(int8_t gain);
+
+    // Y_FINE_GAIN register
+    int8_t getYFineGain();
+    void setYFineGain(int8_t gain);
+
+    // Z_FINE_GAIN register
+    int8_t getZFineGain();
+    void setZFineGain(int8_t gain);
+
+    // XA_OFFS_* registers
+    int16_t getXAccelOffset();
+    void setXAccelOffset(int16_t offset);
+
+    // YA_OFFS_* register
+    int16_t getYAccelOffset();
+    void setYAccelOffset(int16_t offset);
+
+    // ZA_OFFS_* register
+    int16_t getZAccelOffset();
+    void setZAccelOffset(int16_t offset);
+
+    // XG_OFFS_USR* registers
+    int16_t getXGyroOffset();
+    void setXGyroOffset(int16_t offset);
+
+    // YG_OFFS_USR* register
+    int16_t getYGyroOffset();
+    void setYGyroOffset(int16_t offset);
+
+    // ZG_OFFS_USR* register
+    int16_t getZGyroOffset();
+    void setZGyroOffset(int16_t offset);
+
+    // INT_ENABLE register (DMP functions)
+    bool getIntPLLReadyEnabled();
+    void setIntPLLReadyEnabled(bool enabled);
+    bool getIntDMPEnabled();
+    void setIntDMPEnabled(bool enabled);
+
+    // DMP_INT_STATUS
+    bool getDMPInt5Status();
+    bool getDMPInt4Status();
+    bool getDMPInt3Status();
+    bool getDMPInt2Status();
+    bool getDMPInt1Status();
+    bool getDMPInt0Status();
+
+    // INT_STATUS register (DMP functions)
+    bool getIntPLLReadyStatus();
+    bool getIntDMPStatus();
+
+    // USER_CTRL register (DMP functions)
+    bool getDMPEnabled();
+    void setDMPEnabled(bool enabled);
+    void resetDMP();
+
+    // BANK_SEL register
+    void setMemoryBank(uint8_t bank, bool prefetchEnabled = false,
+                       bool userBank = false);
+
+    // MEM_START_ADDR register
+    void setMemoryStartAddress(uint8_t address);
+
+    // MEM_R_W register
+    uint8_t readMemoryByte();
+    void writeMemoryByte(uint8_t data);
+    void readMemoryBlock(uint8_t* data, uint16_t dataSize, uint8_t bank = 0,
+                         uint8_t address = 0);
+    bool writeMemoryBlock(const uint8_t* data, uint16_t dataSize,
+                          uint8_t bank = 0, uint8_t address = 0,
+                          bool verify = true, bool useProgMem = false);
+    bool writeProgMemoryBlock(const uint8_t* data, uint16_t dataSize,
+                              uint8_t bank = 0, uint8_t address = 0,
+                              bool verify = true);
+
+    bool writeDMPConfigurationSet(const uint8_t* data, uint16_t dataSize,
+                                  bool useProgMem = false);
+    bool writeProgDMPConfigurationSet(const uint8_t* data, uint16_t dataSize);
+
+    // DMP_CFG_1 register
+    uint8_t getDMPConfig1();
+    void setDMPConfig1(uint8_t config);
+
+    // DMP_CFG_2 register
+    uint8_t getDMPConfig2();
+    void setDMPConfig2(uint8_t config);
+
+// special methods for MotionApps 2.0 implementation
+#ifdef MPU6050_INCLUDE_DMP_MOTIONAPPS20
+    uint8_t* dmpPacketBuffer;
+    uint16_t dmpPacketSize;
+
+    uint8_t dmpInitialize();
+    bool dmpPacketAvailable();
+
+    uint8_t dmpSetFIFORate(uint8_t fifoRate);
+    uint8_t dmpGetFIFORate();
+    uint8_t dmpGetSampleStepSizeMS();
+    uint8_t dmpGetSampleFrequency();
+    int32_t dmpDecodeTemperature(int8_t tempReg);
+
+    // Register callbacks after a packet of FIFO data is processed
+    // uint8_t dmpRegisterFIFORateProcess(inv_obj_func func, int16_t priority);
+    // uint8_t dmpUnregisterFIFORateProcess(inv_obj_func func);
+    uint8_t dmpRunFIFORateProcesses();
+
+    // Setup FIFO for various output
+    uint8_t dmpSendQuaternion(uint_fast16_t accuracy);
+    uint8_t dmpSendGyro(uint_fast16_t elements, uint_fast16_t accuracy);
+    uint8_t dmpSendAccel(uint_fast16_t elements, uint_fast16_t accuracy);
+    uint8_t dmpSendLinearAccel(uint_fast16_t elements, uint_fast16_t accuracy);
+    uint8_t dmpSendLinearAccelInWorld(uint_fast16_t elements,
+                                      uint_fast16_t accuracy);
+    uint8_t dmpSendControlData(uint_fast16_t elements, uint_fast16_t accuracy);
+    uint8_t dmpSendSensorData(uint_fast16_t elements, uint_fast16_t accuracy);
+    uint8_t dmpSendExternalSensorData(uint_fast16_t elements,
+                                      uint_fast16_t accuracy);
+    uint8_t dmpSendGravity(uint_fast16_t elements, uint_fast16_t accuracy);
+    uint8_t dmpSendPacketNumber(uint_fast16_t accuracy);
+    uint8_t dmpSendQuantizedAccel(uint_fast16_t elements,
+                                  uint_fast16_t accuracy);
+    uint8_t dmpSendEIS(uint_fast16_t elements, uint_fast16_t accuracy);
+
+    // Get Fixed Point data from FIFO
+    uint8_t dmpGetAccel(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetAccel(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetAccel(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetQuaternion(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetQuaternion(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetQuaternion(Quaternion* q, const uint8_t* packet = 0);
+    uint8_t dmpGet6AxisQuaternion(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGet6AxisQuaternion(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGet6AxisQuaternion(Quaternion* q, const uint8_t* packet = 0);
+    uint8_t dmpGetRelativeQuaternion(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetRelativeQuaternion(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetRelativeQuaternion(Quaternion* data,
+                                     const uint8_t* packet = 0);
+    uint8_t dmpGetGyro(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGyro(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGyro(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpSetLinearAccelFilterCoefficient(float coef);
+    uint8_t dmpGetLinearAccel(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetLinearAccel(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetLinearAccel(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetLinearAccel(VectorInt16* v, VectorInt16* vRaw,
+                              VectorFloat* gravity);
+    uint8_t dmpGetLinearAccelInWorld(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetLinearAccelInWorld(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetLinearAccelInWorld(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetLinearAccelInWorld(VectorInt16* v, VectorInt16* vReal,
+                                     Quaternion* q);
+    uint8_t dmpGetGyroAndAccelSensor(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGyroAndAccelSensor(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGyroAndAccelSensor(VectorInt16* g, VectorInt16* a,
+                                     const uint8_t* packet = 0);
+    uint8_t dmpGetGyroSensor(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGyroSensor(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGyroSensor(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetControlData(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dm pGetTemperature(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGravity(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGravity(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGravity(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetGravity(VectorFloat* v, Quaternion* q);
+    uint8_t dmpGetUnquantizedAccel(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetUnquantizedAccel(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetUnquantizedAccel(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetQuantizedAccel(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetQuantizedAccel(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetQuantizedAccel(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetExternalSensorData(int32_t* data, uint16_t size,
+                                     const uint8_t* packet = 0);
+    uint8_t dmpGetEIS(int32_t* data, const uint8_t* packet = 0);
+
+    uint8_t dmpGetEuler(float* data, Quaternion* q);
+    uint8_t dmpGetYawPitchRoll(float* data, Quaternion* q,
+                               VectorFloat* gravity);
+
+    // Get Floating Point data from FIFO
+    uint8_t dmpGetAccelFloat(float* data, const uint8_t* packet = 0);
+    uint8_t dmpGetQuaternionFloat(float* data, const uint8_t* packet = 0);
+
+    uint8_t dmpProcessFIFOPacket(const unsigned char* dmpData);
+    uint8_t dmpReadAndProcessFIFOPacket(uint8_t numPackets,
+                                        uint8_t* processed = NULL);
+
+    uint8_t dmpSetFIFOProcessedCallback(void (*func)(void));
+
+    uint8_t dmpInitFIFOParam();
+    uint8_t dmpCloseFIFO();
+    uint8_t dmpSetGyroDataSource(uint8_t source);
+    uint8_t dmpDecodeQuantizedAccel();
+    uint32_t dmpGetGyroSumOfSquare();
+    uint32_t dmpGetAccelSumOfSquare();
+    void dmpOverrideQuaternion(long* q);
+    uint16_t dmpGetFIFOPacketSize();
+#endif
+
+// special methods for MotionApps 4.1 implementation
+#ifdef MPU6050_INCLUDE_DMP_MOTIONAPPS41
+    uint8_t* dmpPacketBuffer;
+    uint16_t dmpPacketSize;
+
+    uint8_t dmpInitialize();
+    bool dmpPacketAvailable();
+
+    uint8_t dmpSetFIFORate(uint8_t fifoRate);
+    uint8_t dmpGetFIFORate();
+    uint8_t dmpGetSampleStepSizeMS();
+    uint8_t dmpGetSampleFrequency();
+    int32_t dmpDecodeTemperature(int8_t tempReg);
+
+    // Register callbacks after a packet of FIFO data is processed
+    // uint8_t dmpRegisterFIFORateProcess(inv_obj_func func, int16_t priority);
+    // uint8_t dmpUnregisterFIFORateProcess(inv_obj_func func);
+    uint8_t dmpRunFIFORateProcesses();
+
+    // Setup FIFO for various output
+    uint8_t dmpSendQuaternion(uint_fast16_t accuracy);
+    uint8_t dmpSendGyro(uint_fast16_t elements, uint_fast16_t accuracy);
+    uint8_t dmpSendAccel(uint_fast16_t elements, uint_fast16_t accuracy);
+    uint8_t dmpSendLinearAccel(uint_fast16_t elements, uint_fast16_t accuracy);
+    uint8_t dmpSendLinearAccelInWorld(uint_fast16_t elements,
+                                      uint_fast16_t accuracy);
+    uint8_t dmpSendControlData(uint_fast16_t elements, uint_fast16_t accuracy);
+    uint8_t dmpSendSensorData(uint_fast16_t elements, uint_fast16_t accuracy);
+    uint8_t dmpSendExternalSensorData(uint_fast16_t elements,
+                                      uint_fast16_t accuracy);
+    uint8_t dmpSendGravity(uint_fast16_t elements, uint_fast16_t accuracy);
+    uint8_t dmpSendPacketNumber(uint_fast16_t accuracy);
+    uint8_t dmpSendQuantizedAccel(uint_fast16_t elements,
+                                  uint_fast16_t accuracy);
+    uint8_t dmpSendEIS(uint_fast16_t elements, uint_fast16_t accuracy);
+
+    // Get Fixed Point data from FIFO
+    uint8_t dmpGetAccel(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetAccel(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetAccel(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetQuaternion(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetQuaternion(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetQuaternion(Quaternion* q, const uint8_t* packet = 0);
+    uint8_t dmpGet6AxisQuaternion(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGet6AxisQuaternion(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGet6AxisQuaternion(Quaternion* q, const uint8_t* packet = 0);
+    uint8_t dmpGetRelativeQuaternion(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetRelativeQuaternion(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetRelativeQuaternion(Quaternion* data,
+                                     const uint8_t* packet = 0);
+    uint8_t dmpGetGyro(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGyro(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGyro(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetMag(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpSetLinearAccelFilterCoefficient(float coef);
+    uint8_t dmpGetLinearAccel(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetLinearAccel(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetLinearAccel(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetLinearAccel(VectorInt16* v, VectorInt16* vRaw,
+                              VectorFloat* gravity);
+    uint8_t dmpGetLinearAccelInWorld(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetLinearAccelInWorld(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetLinearAccelInWorld(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetLinearAccelInWorld(VectorInt16* v, VectorInt16* vReal,
+                                     Quaternion* q);
+    uint8_t dmpGetGyroAndAccelSensor(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGyroAndAccelSensor(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGyroAndAccelSensor(VectorInt16* g, VectorInt16* a,
+                                     const uint8_t* packet = 0);
+    uint8_t dmpGetGyroSensor(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGyroSensor(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGyroSensor(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetControlData(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetTemperature(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGravity(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGravity(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetGravity(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetGravity(VectorFloat* v, Quaternion* q);
+    uint8_t dmpGetUnquantizedAccel(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetUnquantizedAccel(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetUnquantizedAccel(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetQuantizedAccel(int32_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetQuantizedAccel(int16_t* data, const uint8_t* packet = 0);
+    uint8_t dmpGetQuantizedAccel(VectorInt16* v, const uint8_t* packet = 0);
+    uint8_t dmpGetExternalSensorData(int32_t* data, uint16_t size,
+                                     const uint8_t* packet = 0);
+    uint8_t dmpGetEIS(int32_t* data, const uint8_t* packet = 0);
+
+    uint8_t dmpGetEuler(float* data, Quaternion* q);
+    uint8_t dmpGetYawPitchRoll(float* data, Quaternion* q,
+                               VectorFloat* gravity);
+
+    // Get Floating Point data from FIFO
+    uint8_t dmpGetAccelFloat(float* data, const uint8_t* packet = 0);
+    uint8_t dmpGetQuaternionFloat(float* data, const uint8_t* packet = 0);
+
+    uint8_t dmpProcessFIFOPacket(const unsigned char* dmpData);
+    uint8_t dmpReadAndProcessFIFOPacket(uint8_t numPackets,
+                                        uint8_t* processed = NULL);
+
+    uint8_t dmpSetFIFOProcessedCallback(void (*func)(void));
+
+    uint8_t dmpInitFIFOParam();
+    uint8_t dmpCloseFIFO();
+    uint8_t dmpSetGyroDataSource(uint8_t source);
+    uint8_t dmpDecodeQuantizedAccel();
+    uint32_t dmpGetGyroSumOfSquare();
+    uint32_t dmpGetAccelSumOfSquare();
+    void dmpOverrideQuaternion(long* q);
+    uint16_t dmpGetFIFOPacketSize();
+#endif
+
+private:
+    uint8_t devAddr;
+    uint8_t buffer[14];
 };
 
 #endif /* _MPU6050_H_ */

--- a/lib/drivers/rtos-i2c/I2CMasterRtos.hpp
+++ b/lib/drivers/rtos-i2c/I2CMasterRtos.hpp
@@ -18,9 +18,8 @@ public:
     *  @note Has to be created in a thread context, i.e. within the main or some
     * other function. A global delaration does not work
     */
-    I2CMasterRtos(std::shared_ptr<SharedI2C> sharedI2C) : SharedI2CDevice(sharedI2C) {
-        
-    }
+    I2CMasterRtos(std::shared_ptr<SharedI2C> sharedI2C)
+        : SharedI2CDevice(sharedI2C) {}
 
     /** Set the frequency of the I2C interface
      *

--- a/lib/drivers/rtos-i2c/I2CMasterRtos.hpp
+++ b/lib/drivers/rtos-i2c/I2CMasterRtos.hpp
@@ -1,16 +1,14 @@
 #pragma once
 
 #include "I2CDriver.hpp"
+#include "SharedI2C.hpp"
 
 namespace mbed {
 
 /// I2C master interface to the RTOS-I2CDriver.
 /// The interface is compatible to the original mbed I2C class.
 /// Provides an additonal "read from register"-function.
-class I2CMasterRtos {
-protected:
-    I2CDriver m_drv;
-
+class I2CMasterRtos : public SharedI2CDevice {
 public:
     /** Create an I2C Master interface, connected to the specified pins
     *
@@ -20,14 +18,15 @@ public:
     *  @note Has to be created in a thread context, i.e. within the main or some
     * other function. A global delaration does not work
     */
-    I2CMasterRtos(PinName sda, PinName scl, int freq = 400000)
-        : m_drv(sda, scl, freq) {}
+    I2CMasterRtos(std::shared_ptr<SharedI2C> sharedI2C) : SharedI2CDevice(sharedI2C) {
+        
+    }
 
     /** Set the frequency of the I2C interface
      *
      *  @param hz The bus frequency in hertz
      */
-    void frequency(int hz) { m_drv.frequency(hz); }
+    void frequency(int hz) { m_i2c->frequency(hz); }
 
     /** Read from an I2C slave
      *
@@ -44,7 +43,7 @@ public:
      *   non-0 on failure (nack)
      */
     int read(int address, char* data, int length = 1, bool repeated = false) {
-        return m_drv.readMaster(address, data, length, repeated);
+        return m_i2c->readMaster(address, data, length, repeated);
     }
 
     /** Read from a given I2C slave register
@@ -65,7 +64,7 @@ public:
     */
     int read(int address, uint8_t _register, char* data, int length = 1,
              bool repeated = false) {
-        return m_drv.readMaster(address, _register, data, length, repeated);
+        return m_i2c->readMaster(address, _register, data, length, repeated);
     }
 
     /** Read a single byte from the I2C bus
@@ -75,7 +74,7 @@ public:
      *  @returns
      *    the byte read
      */
-    int read(int ack) { return m_drv.readMaster(ack); }
+    int read(int ack) { return m_i2c->readMaster(ack); }
 
     /** Write to an I2C slave
      *
@@ -93,7 +92,7 @@ public:
      */
     int write(int address, const char* data, int length = 1,
               bool repeated = false) {
-        return m_drv.writeMaster(address, data, length, repeated);
+        return m_i2c->writeMaster(address, data, length, repeated);
     }
 
     /** Write single byte out on the I2C bus
@@ -104,19 +103,19 @@ public:
      *    '1' if an ACK was received,
      *    '0' otherwise
      */
-    int write(int data) { return m_drv.writeMaster(data); }
+    int write(int data) { return m_i2c->writeMaster(data); }
 
     /** Creates a start condition on the I2C bus
      */
 
-    void start() { m_drv.startMaster(); }
+    void start() { m_i2c->startMaster(); }
 
     /// Creates a stop condition on the I2C bus
     /// If unsccessful because someone on the bus holds the scl line down it
     /// returns "false" after 23µs
     /// In normal operation the stop shouldn't take longer than 12µs @ 100kHz
     /// and 3-4µs @ 400kHz.
-    bool stop() { return m_drv.stopMaster(); }
+    bool stop() { return m_i2c->stopMaster(); }
 
     /// Wait until the interface becomes available.
     ///
@@ -125,9 +124,9 @@ public:
     /// There's no need to call this function for running single request,
     /// because all driver functions
     /// will lock the device for exclusive access automatically.
-    void lock() { m_drv.lock(); }
+    void lock() { m_i2c->lock(); }
 
     /// Unlock the interface that has previously been locked by the same thread.
-    void unlock() { m_drv.unlock(); }
+    void unlock() { m_i2c->unlock(); }
 };
 }

--- a/lib/drivers/rtos-i2c/SharedI2C.cpp
+++ b/lib/drivers/rtos-i2c/SharedI2C.cpp
@@ -1,4 +1,3 @@
 #include "SharedI2C.hpp"
 
 uint8_t SharedI2C::m_objectCount = 0;
-

--- a/lib/drivers/rtos-i2c/SharedI2C.cpp
+++ b/lib/drivers/rtos-i2c/SharedI2C.cpp
@@ -1,0 +1,4 @@
+#include "SharedI2C.hpp"
+
+uint8_t SharedI2C::m_objectCount = 0;
+

--- a/lib/drivers/rtos-i2c/SharedI2C.hpp
+++ b/lib/drivers/rtos-i2c/SharedI2C.hpp
@@ -22,9 +22,7 @@ class SharedI2CDevice {
 public:
     using I2CPtrT = std::shared_ptr<SharedI2C>;
 
-    SharedI2CDevice(I2CPtrT i2c) : m_i2c(i2c) {
-        ASSERT(i2c != nullptr);
-    }
+    SharedI2CDevice(I2CPtrT i2c) : m_i2c(i2c) { ASSERT(i2c != nullptr); }
 
 protected:
     I2CPtrT m_i2c;

--- a/lib/drivers/rtos-i2c/SharedI2C.hpp
+++ b/lib/drivers/rtos-i2c/SharedI2C.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Assert.hpp"
+#include "I2CDriver.hpp"
+#include "Mbed.hpp"
+#include "Rtos.hpp"
+
+#include <memory>
+
+class SharedI2C : public I2CDriver {
+public:
+    SharedI2C(PinName sda, PinName scl, int freq) : I2CDriver(sda, scl, freq) {
+        ++m_objectCount;
+        ASSERT(m_objectCount == 1);
+    }
+
+private:
+    static uint8_t m_objectCount;
+};
+
+class SharedI2CDevice {
+public:
+    using I2CPtrT = std::shared_ptr<SharedI2C>;
+
+    SharedI2CDevice(I2CPtrT i2c) : m_i2c(i2c) {
+        ASSERT(i2c != nullptr);
+    }
+
+protected:
+    I2CPtrT m_i2c;
+};

--- a/src/control/config/RobotDevices.hpp
+++ b/src/control/config/RobotDevices.hpp
@@ -4,3 +4,5 @@
 #include "rc-fshare/git_version.hpp"
 #include "pins-control.hpp"
 #include "robot-config.hpp"
+
+extern shared_ptr<SharedI2C> shared_i2c;

--- a/src/control/config/robot-config.hpp
+++ b/src/control/config/robot-config.hpp
@@ -15,3 +15,6 @@
 // Period of kicker status updates
 // This will affect how quickly changes in breakbeam make their way up to soccer
 #define RJ_KICKER_UPDATE_PERIOD_MS 25
+
+// I2C freq
+#define RJ_I2C_FREQ 400000

--- a/src/control/main.cpp
+++ b/src/control/main.cpp
@@ -234,28 +234,29 @@ int main() {
     }
     rgbLED.write();
 
-    int16_t ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset;
+    // int16_t ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset;
 
-    FILE *fp = fopen("/local/offsets.txt", "r");  // Open "out.txt" on the local file system for writing
-    int success = 0;
-    // printf("opening gyro offsets file\r\n");
-    if (fp != nullptr) {
-        success = fscanf(fp, "%d %d %d %d %d %d", &ax_offset, &ay_offset, &az_offset,
-                                                  &gx_offset, &gy_offset, &gz_offset);
-        printf("fscanf done of gyro offsets\r\n");
-        fclose(fp);
-        printf("closed gyro offset file\r\n");
-    }
+    // FILE *fp = fopen("/local/offsets.txt", "r");  // Open "out.txt" on the local file system for writing
+    // int success = 0;
+    // // printf("opening gyro offsets file\r\n");
+    // if (fp != nullptr) {
+        // success = fscanf(fp, "%d %d %d %d %d %d", &ax_offset, &ay_offset, &az_offset,
+                                                  // &gx_offset, &gy_offset, &gz_offset);
+        // printf("fscanf done of gyro offsets\r\n");
+        // fclose(fp);
+        // printf("closed gyro offset file\r\n");
+    // }
 
-    printf("vals: %d %d %d %d %d %d\r\n", ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset);
+    // printf("vals: %d %d %d %d %d %d\r\n", ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset);
 
-    if (success == 6) {
-        printf("Successfully imported offsets from offsets.txt\r\n");
-    } else {
-        printf("Failed to import offsets from offsets.txt, defaulting to 0\r\n");
-    }
-
-    Task_Controller_UpdateOffsets(ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset);
+    // if (success == 6) {
+        // printf("Successfully imported offsets from offsets.txt\r\n");
+    // } else {
+        // printf("Failed to import offsets from offsets.txt, defaulting to 0\r\n");
+    // }
+    // -1825 2134 6841 27 0 28
+    Task_Controller_UpdateOffsets(-1825, 2134, 6841, 27, 0, 28);
+    // Task_Controller_UpdateOffsets(ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset);
 
     // DigitalOut rdy_led(RJ_RDY_LED, !fpgaInitialized);
 

--- a/src/control/main.cpp
+++ b/src/control/main.cpp
@@ -15,6 +15,7 @@
 #include "RotarySelector.hpp"
 #include "Rtos.hpp"
 #include "RtosTimerHelper.hpp"
+#include "SharedI2C.hpp"
 #include "SharedSPI.hpp"
 #include "TaskSignals.hpp"
 #include "Watchdog.hpp"
@@ -82,6 +83,9 @@ std::array<int16_t, 4> Task_Controller_EncGetClear();
 void InitializeCommModule(SharedSPIDevice<>::SpiPtrT sharedSPI);
 
 extern std::array<WheelStallDetection, 4> wheelStallDetection;
+
+// A shared I2C bus
+std::shared_ptr<SharedI2C> shared_i2c = make_shared<SharedI2C>(RJ_I2C_SDA, RJ_I2C_SCL, RJ_I2C_FREQ);
 
 /**
  * @brief Sets the hardware configurations for the status LEDs & places
@@ -258,7 +262,7 @@ int main() {
     // Init IO Expander and turn all LEDs on.  The first parameter to config()
     // sets the first 8 lines to input and the last 8 to output.  The pullup
     // resistors and polarity swap are enabled for the 4 rotary selector lines.
-    MCP23017 ioExpander(RJ_I2C_SDA, RJ_I2C_SCL, RJ_IO_EXPANDER_I2C_ADDRESS);
+    MCP23017 ioExpander(shared_i2c, RJ_IO_EXPANDER_I2C_ADDRESS);
     ioExpander.config(0x00FF, 0x00ff, 0x00ff);
     ioExpander.writeMask(static_cast<uint16_t>(~IOExpanderErrorLEDMask),
                          IOExpanderErrorLEDMask);

--- a/src/control/main.cpp
+++ b/src/control/main.cpp
@@ -85,7 +85,8 @@ void InitializeCommModule(SharedSPIDevice<>::SpiPtrT sharedSPI);
 extern std::array<WheelStallDetection, 4> wheelStallDetection;
 
 // A shared I2C bus
-std::shared_ptr<SharedI2C> shared_i2c = make_shared<SharedI2C>(RJ_I2C_SDA, RJ_I2C_SCL, RJ_I2C_FREQ);
+std::shared_ptr<SharedI2C> shared_i2c =
+    make_shared<SharedI2C>(RJ_I2C_SDA, RJ_I2C_SCL, RJ_I2C_FREQ);
 
 /**
  * @brief Sets the hardware configurations for the status LEDs & places
@@ -185,7 +186,6 @@ int main() {
     rgbLED.setPixel(1, red, green, blue);
     rgbLED.write();
 
-
     // Set neopixel 1 to purple if git version is dirty
     if (git_version_dirty) {
         rgbLED.setPixel(1, NeoColorPurple);
@@ -236,27 +236,32 @@ int main() {
 
     int16_t ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset;
 
-    FILE *fp = fopen("/local/offsets.txt", "r");  // Open "out.txt" on the local file system for writing
+    FILE* fp =
+        fopen("/local/offsets.txt",
+              "r");  // Open "out.txt" on the local file system for writing
     int success = 0;
     // printf("opening gyro offsets file\r\n");
     if (fp != nullptr) {
-        success = fscanf(fp, "%d %d %d %d %d %d", &ax_offset, &ay_offset, &az_offset,
-                                                  &gx_offset, &gy_offset, &gz_offset);
+        success = fscanf(fp, "%d %d %d %d %d %d", &ax_offset, &ay_offset,
+                         &az_offset, &gx_offset, &gy_offset, &gz_offset);
         printf("fscanf done of gyro offsets\r\n");
         fclose(fp);
         printf("closed gyro offset file\r\n");
     }
 
-    printf("vals: %d %d %d %d %d %d\r\n", ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset);
+    printf("vals: %d %d %d %d %d %d\r\n", ax_offset, ay_offset, az_offset,
+           gx_offset, gy_offset, gz_offset);
 
     if (success == 6) {
         printf("Successfully imported offsets from offsets.txt\r\n");
     } else {
-        printf("Failed to import offsets from offsets.txt, defaulting to 0\r\n");
+        printf(
+            "Failed to import offsets from offsets.txt, defaulting to 0\r\n");
     }
     // -1825 2134 6841 27 0 28
     // Task_Controller_UpdateOffsets(-1825, 2134, 6841, 27, 0, 28);
-    Task_Controller_UpdateOffsets(ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset);
+    Task_Controller_UpdateOffsets(ax_offset, ay_offset, az_offset, gx_offset,
+                                  gy_offset, gz_offset);
 
     // DigitalOut rdy_led(RJ_RDY_LED, !fpgaInitialized);
 
@@ -298,9 +303,9 @@ int main() {
     Thread::signal_wait(MAIN_TASK_CONTINUE, osWaitForever);
 
 #ifndef NDEBUG
-    // Start the thread task for the serial console
-    // Thread console_task(Task_SerialConsole, mainID, osPriorityBelowNormal);
-    // Thread::signal_wait(MAIN_TASK_CONTINUE, osWaitForever);
+// Start the thread task for the serial console
+// Thread console_task(Task_SerialConsole, mainID, osPriorityBelowNormal);
+// Thread::signal_wait(MAIN_TASK_CONTINUE, osWaitForever);
 #endif
 
     // Initialize CommModule and radio
@@ -422,7 +427,7 @@ int main() {
     // Release each thread into its operations in a structured manner
     controller_task.signal_set(SUB_TASK_CONTINUE);
 #ifndef NDEBUG
-    // console_task.signal_set(SUB_TASK_CONTINUE);
+// console_task.signal_set(SUB_TASK_CONTINUE);
 #endif
 
 // #pragma for gcc has bugs in it for selectively disabling warnings

--- a/src/control/main.cpp
+++ b/src/control/main.cpp
@@ -234,29 +234,29 @@ int main() {
     }
     rgbLED.write();
 
-    // int16_t ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset;
+    int16_t ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset;
 
-    // FILE *fp = fopen("/local/offsets.txt", "r");  // Open "out.txt" on the local file system for writing
-    // int success = 0;
-    // // printf("opening gyro offsets file\r\n");
-    // if (fp != nullptr) {
-        // success = fscanf(fp, "%d %d %d %d %d %d", &ax_offset, &ay_offset, &az_offset,
-                                                  // &gx_offset, &gy_offset, &gz_offset);
-        // printf("fscanf done of gyro offsets\r\n");
-        // fclose(fp);
-        // printf("closed gyro offset file\r\n");
-    // }
+    FILE *fp = fopen("/local/offsets.txt", "r");  // Open "out.txt" on the local file system for writing
+    int success = 0;
+    // printf("opening gyro offsets file\r\n");
+    if (fp != nullptr) {
+        success = fscanf(fp, "%d %d %d %d %d %d", &ax_offset, &ay_offset, &az_offset,
+                                                  &gx_offset, &gy_offset, &gz_offset);
+        printf("fscanf done of gyro offsets\r\n");
+        fclose(fp);
+        printf("closed gyro offset file\r\n");
+    }
 
-    // printf("vals: %d %d %d %d %d %d\r\n", ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset);
+    printf("vals: %d %d %d %d %d %d\r\n", ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset);
 
-    // if (success == 6) {
-        // printf("Successfully imported offsets from offsets.txt\r\n");
-    // } else {
-        // printf("Failed to import offsets from offsets.txt, defaulting to 0\r\n");
-    // }
+    if (success == 6) {
+        printf("Successfully imported offsets from offsets.txt\r\n");
+    } else {
+        printf("Failed to import offsets from offsets.txt, defaulting to 0\r\n");
+    }
     // -1825 2134 6841 27 0 28
-    Task_Controller_UpdateOffsets(-1825, 2134, 6841, 27, 0, 28);
-    // Task_Controller_UpdateOffsets(ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset);
+    // Task_Controller_UpdateOffsets(-1825, 2134, 6841, 27, 0, 28);
+    Task_Controller_UpdateOffsets(ax_offset, ay_offset, az_offset, gx_offset, gy_offset, gz_offset);
 
     // DigitalOut rdy_led(RJ_RDY_LED, !fpgaInitialized);
 
@@ -299,8 +299,8 @@ int main() {
 
 #ifndef NDEBUG
     // Start the thread task for the serial console
-    Thread console_task(Task_SerialConsole, mainID, osPriorityBelowNormal);
-    Thread::signal_wait(MAIN_TASK_CONTINUE, osWaitForever);
+    // Thread console_task(Task_SerialConsole, mainID, osPriorityBelowNormal);
+    // Thread::signal_wait(MAIN_TASK_CONTINUE, osWaitForever);
 #endif
 
     // Initialize CommModule and radio
@@ -422,7 +422,7 @@ int main() {
     // Release each thread into its operations in a structured manner
     controller_task.signal_set(SUB_TASK_CONTINUE);
 #ifndef NDEBUG
-    console_task.signal_set(SUB_TASK_CONTINUE);
+    // console_task.signal_set(SUB_TASK_CONTINUE);
 #endif
 
 // #pragma for gcc has bugs in it for selectively disabling warnings

--- a/src/control/modules/ControllerTaskThread.cpp
+++ b/src/control/modules/ControllerTaskThread.cpp
@@ -22,7 +22,7 @@
 
 // Keep this pretty high for now. Ideally, drop it down to ~3 for production
 // builds. Hopefully that'll be possible without the console
-constexpr auto CONTROL_LOOP_WAIT_MS = 8;
+constexpr auto CONTROL_LOOP_WAIT_MS = 5;
 
 // initialize PID controller
 PidMotionController pidController;

--- a/src/control/modules/ControllerTaskThread.cpp
+++ b/src/control/modules/ControllerTaskThread.cpp
@@ -22,7 +22,7 @@
 
 // Keep this pretty high for now. Ideally, drop it down to ~3 for production
 // builds. Hopefully that'll be possible without the console
-constexpr auto CONTROL_LOOP_WAIT_MS = 50;
+constexpr auto CONTROL_LOOP_WAIT_MS = 5;
 
 // initialize PID controller
 PidMotionController pidController;
@@ -175,6 +175,7 @@ void Task_Controller(const void* args) {
          *
          */
         const float dt = enc_deltas.back() * (1 / 18.432e6) * 2 * 128;
+        // const float dt = 1.0f / (CONTROL_LOOP_WAIT_MS / 1000.0f);
 
         // take first 4 encoder deltas
         std::array<int16_t, 4> driveMotorEnc;

--- a/src/control/modules/ControllerTaskThread.cpp
+++ b/src/control/modules/ControllerTaskThread.cpp
@@ -22,7 +22,7 @@
 
 // Keep this pretty high for now. Ideally, drop it down to ~3 for production
 // builds. Hopefully that'll be possible without the console
-constexpr auto CONTROL_LOOP_WAIT_MS = 5;
+constexpr auto CONTROL_LOOP_WAIT_MS = 8;
 
 // initialize PID controller
 PidMotionController pidController;

--- a/src/control/modules/ControllerTaskThread.cpp
+++ b/src/control/modules/ControllerTaskThread.cpp
@@ -22,7 +22,7 @@
 
 // Keep this pretty high for now. Ideally, drop it down to ~3 for production
 // builds. Hopefully that'll be possible without the console
-constexpr auto CONTROL_LOOP_WAIT_MS = 5;
+constexpr auto CONTROL_LOOP_WAIT_MS = 50;
 
 // initialize PID controller
 PidMotionController pidController;
@@ -47,6 +47,11 @@ void Task_Controller_UpdateTarget(Eigen::Vector3f targetVel) {
     commandTimedOut = false;
     if (commandTimeoutTimer)
         commandTimeoutTimer->start(COMMAND_TIMEOUT_INTERVAL);
+}
+
+void Task_Controller_UpdateOffsets(int16_t ax, int16_t ay, int16_t az,
+                                   int16_t gx, int16_t gy, int16_t gz) {
+    pidController.startGyro(ax, ay, az, gx, gy, gz);
 }
 
 constexpr uint8_t DRIBBLER_SPEED_UPPERBOUND = 128;

--- a/src/control/modules/motion-control/PidMotionController.hpp
+++ b/src/control/modules/motion-control/PidMotionController.hpp
@@ -123,7 +123,7 @@ public:
         float target_w = _targetVel[2];
         target_w = rotation_pid.run(rotation); // rotation pid to do an angular hold
         // correct target velocity to include rotation hold
-        _targetVel[2] += target_w;
+        _targetVel[2] -= target_w;
 
         // conversion to commanded wheel velocities
         Eigen::Vector4d targetWheelVels = RobotModel::get().BotToWheel * _targetVel.cast<double>();

--- a/src/control/modules/motion-control/PidMotionController.hpp
+++ b/src/control/modules/motion-control/PidMotionController.hpp
@@ -3,6 +3,8 @@
 #include <array>
 #include <rc-fshare/pid.hpp>
 #include <rc-fshare/robot_model.hpp>
+
+#include "MPU6050.h"
 #include "FPGA.hpp"
 
 /**
@@ -10,7 +12,47 @@
  */
 class PidMotionController {
 public:
-    PidMotionController() { setPidValues(3.0, 0, 0, 50, 0); }
+    PidMotionController() : imu(MPU6050_DEFAULT_ADDRESS, RJ_I2C_SDA, RJ_I2C_SCL),
+        ax_offset(0), ay_offset(0), az_offset(0), gx_offset(0), gy_offset(0), gz_offset(0),
+        ax(0), ay(0), az(0), gx(0), gy(0), gz(0), rotation(0), angular_vel(0)
+    { 
+        setPidValues(3.0, 0, 0, 50, 0);
+        imu.initialize();
+
+        FILE *fp = fopen("/local/offsets.txt", "r");  // Open "out.txt" on the local file system for writing
+
+        int success = 0;
+        printf("opening gyro offsets file\r\n");
+        if (fp != nullptr) {
+            success = fscanf(fp, "%d %d %d %d %d %d", &ax_offset, &ay_offset, &az_offset,
+                                                      &gx_offset, &gy_offset, &gz_offset);
+            printf("fscanf done of gyro offsets\r\n");
+            fclose(fp);
+            printf("closed gyro offset file\r\n");
+        }
+
+        if (success == 6) {
+            printf("Successfully imported offsets from offsets.txt\r\n");
+        } else {
+            printf("Failed to import offsets from offsets.txt, defaulting to 0\r\n");
+        }
+
+        Thread::wait(2000);
+
+        imu.setFullScaleGyroRange(MPU6050_GYRO_FS_1000);
+        imu.setFullScaleAccelRange(MPU6050_ACCEL_FS_8);
+
+        imu.setXAccelOffset(ax_offset);
+        imu.setYAccelOffset(ay_offset);
+        imu.setZAccelOffset(az_offset);
+        imu.setXGyroOffset(gx_offset);
+        imu.setYGyroOffset(gy_offset);
+        imu.setZGyroOffset(gz_offset);
+
+        rotation_pid.kp = 5;
+        rotation_pid.ki = 0;
+        rotation_pid.kd = 0;
+    }
 
     void setPidValues(float p, float i, float d, unsigned int windup,
                       float derivAlpha) {
@@ -56,14 +98,38 @@ public:
                                float dt, Eigen::Vector4d* errors = nullptr,
                                Eigen::Vector4d* wheelVelsOut = nullptr,
                                Eigen::Vector4d* targetWheelVelsOut = nullptr) {
-        // convert encoder ticks to rad/s
-        Eigen::Vector4d wheelVels;
-        wheelVels << encoderDeltas[0], encoderDeltas[1], encoderDeltas[2],
-            encoderDeltas[3];
-        wheelVels *= 2.0 * M_PI / ENC_TICKS_PER_TURN / dt;
+        // convert sensor readings to mathematically valid values
+        imu.getMotion6(&ax, &ay, &az, &gx, &gy, &gz);
 
-        Eigen::Vector4d targetWheelVels =
-            RobotModel::get().BotToWheel * _targetVel.cast<double>();
+        Eigen::Vector4d wheelVels;
+        wheelVels << encoderDeltas[0], encoderDeltas[1], encoderDeltas[2], encoderDeltas[3];
+        wheelVels *= 2.0 * M_PI / ENC_TICKS_PER_TURN / dt;
+        auto body_vels = RobotModel::get().WheelToBot * wheelVels;
+
+        // two redundent sensor measurements for rotation
+        float ang_vel_gyro = 32.8 * gz;
+        float ang_vel_enc = body_vels[2];
+
+        std::printf("%f %f\r\n", ang_vel_gyro, ang_vel_enc);
+
+        // perform sensor fusion
+        // the higher this is, the more gyro measurements are used instead of encoders
+        float sensor_fuse_ratio = 0.9;
+        float ang_vel_update = ang_vel_gyro * sensor_fuse_ratio
+                             + ang_vel_enc * sensor_fuse_ratio;
+
+        // perform state update based on fused value
+        float alpha = 0.8;
+        rotation = alpha * ang_vel_update + (1 - alpha) * angular_vel;
+
+        // rotation controller
+        float target_w = _targetVel[2];
+        target_w = rotation_pid.run(rotation); // rotation pid to do an angular hold
+        // correct target velocity to include rotation hold
+        _targetVel[2] += target_w;
+
+        // conversion to commanded wheel velocities
+        Eigen::Vector4d targetWheelVels = RobotModel::get().BotToWheel * _targetVel.cast<double>();
 
         if (targetWheelVelsOut) {
             *targetWheelVelsOut = targetWheelVels;
@@ -127,5 +193,17 @@ private:
     /// controllers for each wheel
     std::array<Pid, 4> _controllers{};
 
+    Pid rotation_pid;
+
     Eigen::Vector3f _targetVel{};
+
+    MPU6050 imu;
+
+    int ax_offset, ay_offset, az_offset,
+        gx_offset, gy_offset, gz_offset;
+    int16_t ax, ay, az,
+            gx, gy, gz;
+
+    float rotation; // state estimate for rotation
+    float angular_vel;
 };

--- a/src/control/modules/motion-control/PidMotionController.hpp
+++ b/src/control/modules/motion-control/PidMotionController.hpp
@@ -4,15 +4,16 @@
 #include <rc-fshare/pid.hpp>
 #include <rc-fshare/robot_model.hpp>
 
-#include "MPU6050.h"
 #include "FPGA.hpp"
+#include "MPU6050.h"
+#include "RobotDevices.hpp"
 
 /**
  * Robot controller that runs a PID loop on each of the four wheels.
  */
 class PidMotionController {
 public:
-    PidMotionController() : imu(MPU6050_DEFAULT_ADDRESS, RJ_I2C_SDA, RJ_I2C_SCL),
+    PidMotionController() : imu(shared_i2c, MPU6050_DEFAULT_ADDRESS),
         ax_offset(0), ay_offset(0), az_offset(0), gx_offset(0), gy_offset(0), gz_offset(0),
         ax(0), ay(0), az(0), gx(0), gy(0), gz(0), rotation(0), angular_vel(0)
     { 

--- a/src/control/modules/motion-control/PidMotionController.hpp
+++ b/src/control/modules/motion-control/PidMotionController.hpp
@@ -108,7 +108,7 @@ public:
 
         // perform sensor fusion
         // the higher this is, the more gyro measurements are used instead of encoders
-        float sensor_fuse_ratio = 0;
+        float sensor_fuse_ratio = 1;
         float ang_vel_update = ang_vel_gyro * sensor_fuse_ratio
                              + ang_vel_enc * (1 - sensor_fuse_ratio);
 
@@ -117,7 +117,7 @@ public:
         angular_vel = (alpha * ang_vel_update + (1 - alpha) * angular_vel);
         rotation += angular_vel * dt;
 
-        // printf("%f\r\n", rotation);
+        // printf("%f\r\n", rotation * 180.0f / M_PI);
 
         // rotation controller
         float target_w = _targetVel[2];

--- a/src/control/modules/motion-control/PidMotionController.hpp
+++ b/src/control/modules/motion-control/PidMotionController.hpp
@@ -89,6 +89,10 @@ public:
                                Eigen::Vector4d* wheelVelsOut = nullptr,
                                Eigen::Vector4d* targetWheelVelsOut = nullptr) {
         // update control targets
+        // in the future, we can get the rotation angle soccer wants and directly command that
+        // as our target, or integrate the rotational velocities given to us to create the target.
+        // For now though, we only do an angle hold when soccer is not commanding rotational velocities
+        // (this should help with strafing quickly)
         // target_rotation += _targetVel[2] * dt;
 
         // get sensor data
@@ -194,7 +198,6 @@ public:
 
             dc += _controllers[i].run(wheelVelErr[i]);
 
-
             if (std::abs(dc) > FPGA::MAX_DUTY_CYCLE) {
                 // Limit to max duty cycle
                 dc = copysign(FPGA::MAX_DUTY_CYCLE, dc);
@@ -204,10 +207,7 @@ public:
                 _controllers[i].set_saturated(false);
             }
 
-            if (i == 0) {
-                // printf("%d\r\n", static_cast<int16_t>(dc));
-            }
-            dutyCycles[i] = (int16_t)dc;
+            dutyCycles[i] = static_cast<int16_t>(dc);
         }
 
         return dutyCycles;

--- a/src/control/modules/motion-control/PidMotionController.hpp
+++ b/src/control/modules/motion-control/PidMotionController.hpp
@@ -19,11 +19,11 @@ public:
     { 
         setPidValues(1.0, 0, 0, 50, 0);
 
-        rotation_pid.kp = 8;
-        rotation_pid.ki = 4;
-        rotation_pid.kd = 0;
+        rotation_pid.kp = 15;
+        rotation_pid.ki = 0;
+        rotation_pid.kd = 300;
         rotation_pid.setWindup(40);
-        // rotation.derivAlpha = .05;
+        rotation_pid.derivAlpha = .10; // 1 is all old, 0 is all new
     }
 
     // can't init gyro in constructor because i2c not fully up?
@@ -120,8 +120,6 @@ public:
         // current rotation estimate
         rotation += angular_vel * dt;
 
-        rotation = std::remainder(rotation, 2*M_PI);
-
         // printf("%f\r\n", rotation * 180.0f / M_PI);
 
         auto target_vel_act = _targetVel;
@@ -130,7 +128,7 @@ public:
         float rot_error = std::atan2(std::sin(target_rotation - rotation),
                                      std::cos(target_rotation - rotation));
         // std::printf("%f\r\n", rot_error);
-        target_vel_act[2] += rotation_pid.run(rot_error);
+        target_vel_act[2] = rotation_pid.run(rot_error);
 
         // conversion to commanded wheel velocities
         Eigen::Vector4d targetWheelVels = RobotModel::get().BotToWheel * target_vel_act.cast<double>();

--- a/src/control/modules/motion-control/PidMotionController.hpp
+++ b/src/control/modules/motion-control/PidMotionController.hpp
@@ -169,8 +169,9 @@ public:
             }
 
             // get the smallest difference between two angles
-            float rot_error = std::atan2(std::sin(target_rotation - rotation),
-                                         std::cos(target_rotation - rotation));
+            float rot_error = target_rotation - rotation;
+            while (rot_error < -M_PI) rot_error += 2 * M_PI;
+            while (rot_error > M_PI) rot_error -= 2 * M_PI;
 
             target_vel_act[2] = rotation_pid.run(rot_error);
         } else {

--- a/src/hw-test/test-imu-calibration.cpp
+++ b/src/hw-test/test-imu-calibration.cpp
@@ -12,36 +12,36 @@
 
 #include "pins-control.hpp"
 
-// Amount of readings used to average, make it higher to get more precision but 
+// Amount of readings used to average, make it higher to get more precision but
 // program will be slower  (default:1000)
 int buffer_size = 1000;
 // Accelerometer error allowed, make it lower to get more precision, but may
 // not converge  (default:8)
 int accel_deadzone = 8;
-// Gyro error allowed, make it lower to get more precision, but sketch may not converge  (default:1)
-int gyro_deadzone=1;
+// Gyro error allowed, make it lower to get more precision, but sketch may not
+// converge  (default:1)
+int gyro_deadzone = 1;
 
-int16_t ax = 0, ay = 0, az = 0,
-        gx = 0, gy = 0, gz = 0;
+int16_t ax = 0, ay = 0, az = 0, gx = 0, gy = 0, gz = 0;
 
-int mean_ax = 0, mean_ay = 0, mean_az = 0,
-    mean_gx = 0, mean_gy = 0, mean_gz = 0;
+int mean_ax = 0, mean_ay = 0, mean_az = 0, mean_gx = 0, mean_gy = 0,
+    mean_gz = 0;
 
 // int state = 0;
-enum State {INIT, RUNNING, FINISHED};
+enum State { INIT, RUNNING, FINISHED };
 
 State state;
 
-int ax_offset = 0, ay_offset = 0, az_offset = 0,
-    gx_offset = 0, gy_offset = 0, gz_offset = 0;
+int ax_offset = 0, ay_offset = 0, az_offset = 0, gx_offset = 0, gy_offset = 0,
+    gz_offset = 0;
 
 void sample();
 void calibration();
 
 Serial pc(RJ_SERIAL_RXTX);
 
-
-std::shared_ptr<SharedI2C> shared_i2c = make_shared<SharedI2C>(RJ_I2C_SDA, RJ_I2C_SCL, RJ_I2C_FREQ);
+std::shared_ptr<SharedI2C> shared_i2c =
+    make_shared<SharedI2C>(RJ_I2C_SDA, RJ_I2C_SCL, RJ_I2C_FREQ);
 MPU6050 imu(shared_i2c, MPU6050_DEFAULT_ADDRESS);
 LocalFileSystem local("local");
 
@@ -56,7 +56,9 @@ int main() {
 
     // start message
     printf("MPU6050 Calibration\r\n");
-    printf("Place MPU6050 flat, package letters facing up. Don't touch it until all axes calibrated.\r\n");
+    printf(
+        "Place MPU6050 flat, package letters facing up. Don't touch it until "
+        "all axes calibrated.\r\n");
     // verify connection
     if (imu.testConnection()) {
         printf("MPU6050 connection successful.\r\n");
@@ -75,7 +77,7 @@ int main() {
     imu.setZGyroOffset(0);
 
     while (true) {
-        if (state == INIT){
+        if (state == INIT) {
             printf("Reading sensors for first time...\r\n");
             sample();
             state = RUNNING;
@@ -93,34 +95,39 @@ int main() {
             sample();
             printf("FINISHED, sensor readings with offsets:\r\n");
 
-            printf("Check that these sensor readings are close to 0 0 16384 0 0 0\r\n");
-            printf("%d %d %d %d %d %d\r\n", mean_ax, mean_ay, mean_az,
-                                            mean_gx, mean_gy, mean_gz);
+            printf(
+                "Check that these sensor readings are close to 0 0 16384 0 0 "
+                "0\r\n");
+            printf("%d %d %d %d %d %d\r\n", mean_ax, mean_ay, mean_az, mean_gx,
+                   mean_gy, mean_gz);
 
             printf("Your offsets:\t\r\n");
             printf("%d %d %d %d %d %d\r\n", ax_offset, ay_offset, az_offset,
-                                            gx_offset, gy_offset, gz_offset);
+                   gx_offset, gy_offset, gz_offset);
 
-            printf("Data is printed as: accelX accelY accelZ gyroX gyroY gyroZ\r\n");
+            printf(
+                "Data is printed as: accelX accelY accelZ gyroX gyroY "
+                "gyroZ\r\n");
 
-            FILE *fp = fopen("/local/offsets.txt", "w");
+            FILE* fp = fopen("/local/offsets.txt", "w");
             if (fp != nullptr) {
-                int res = fprintf(fp, "%d %d %d %d %d %d", ax_offset, ay_offset, az_offset,
-                                                           gx_offset, gy_offset, gz_offset);
+                int res = fprintf(fp, "%d %d %d %d %d %d", ax_offset, ay_offset,
+                                  az_offset, gx_offset, gy_offset, gz_offset);
                 fclose(fp);
 
                 if (res > 0) printf("Offsets written to offsets.txt.");
             }
 
-            while (1);
+            while (1)
+                ;
         }
     }
 }
 
-void sample(){
+void sample() {
     int i = 0;
-    long buff_ax = 0, buff_ay = 0, buff_az = 0,
-         buff_gx = 0, buff_gy = 0, buff_gz = 0;
+    long buff_ax = 0, buff_ay = 0, buff_az = 0, buff_gx = 0, buff_gy = 0,
+         buff_gz = 0;
 
     const int skip_dst = 100;
 
@@ -129,7 +136,7 @@ void sample(){
         imu.getMotion6(&ax, &ay, &az, &gx, &gy, &gz);
 
         // first 100 measures are discarded
-        if (i > skip_dst && i  <=  (buffer_size + skip_dst)) {
+        if (i > skip_dst && i <= (buffer_size + skip_dst)) {
             buff_ax = buff_ax + ax;
             buff_ay = buff_ay + ay;
             buff_az = buff_az + az;
@@ -138,19 +145,19 @@ void sample(){
             buff_gz = buff_gz + gz;
         }
         if (i == (buffer_size + skip_dst)) {
-            mean_ax=buff_ax / buffer_size;
-            mean_ay=buff_ay / buffer_size;
-            mean_az=buff_az / buffer_size;
-            mean_gx=buff_gx / buffer_size;
-            mean_gy=buff_gy / buffer_size;
-            mean_gz=buff_gz / buffer_size;
+            mean_ax = buff_ax / buffer_size;
+            mean_ay = buff_ay / buffer_size;
+            mean_az = buff_az / buffer_size;
+            mean_gx = buff_gx / buffer_size;
+            mean_gy = buff_gy / buffer_size;
+            mean_gz = buff_gz / buffer_size;
         }
         i++;
         Thread::wait(2);
     }
 }
 
-void calibration(){
+void calibration() {
     ax_offset = -mean_ax / 8;
     ay_offset = -mean_ay / 8;
     az_offset = (16384 - mean_az) / 8;
@@ -158,7 +165,7 @@ void calibration(){
     gx_offset = -mean_gx / 4;
     gy_offset = -mean_gy / 4;
     gz_offset = -mean_gz / 4;
-    while (1){
+    while (1) {
         int ready = 0;
         imu.setXAccelOffset(ax_offset);
         imu.setYAccelOffset(ay_offset);
@@ -172,26 +179,38 @@ void calibration(){
 
         printf("...\r\n");
 
-        if (abs(mean_ax) <= accel_deadzone) ready++;
-        else ax_offset = ax_offset - mean_ax / accel_deadzone;
+        if (abs(mean_ax) <= accel_deadzone)
+            ready++;
+        else
+            ax_offset = ax_offset - mean_ax / accel_deadzone;
 
-        if (abs(mean_ay) <= accel_deadzone) ready++;
-        else ay_offset = ay_offset - mean_ay / accel_deadzone;
+        if (abs(mean_ay) <= accel_deadzone)
+            ready++;
+        else
+            ay_offset = ay_offset - mean_ay / accel_deadzone;
 
-        if (abs(16384  -  mean_az) <= accel_deadzone) ready++;
-        else az_offset = az_offset+(16384 - mean_az) / accel_deadzone;
+        if (abs(16384 - mean_az) <= accel_deadzone)
+            ready++;
+        else
+            az_offset = az_offset + (16384 - mean_az) / accel_deadzone;
 
-        if (abs(mean_gx) <= gyro_deadzone) ready++;
-        else gx_offset = gx_offset - mean_gx / (gyro_deadzone+1);
+        if (abs(mean_gx) <= gyro_deadzone)
+            ready++;
+        else
+            gx_offset = gx_offset - mean_gx / (gyro_deadzone + 1);
 
-        if (abs(mean_gy) <= gyro_deadzone) ready++;
-        else gy_offset = gy_offset - mean_gy / (gyro_deadzone+1);
+        if (abs(mean_gy) <= gyro_deadzone)
+            ready++;
+        else
+            gy_offset = gy_offset - mean_gy / (gyro_deadzone + 1);
 
-        if (abs(mean_gz) <= gyro_deadzone) ready++;
-        else gz_offset = gz_offset - mean_gz / (gyro_deadzone+1);
+        if (abs(mean_gz) <= gyro_deadzone)
+            ready++;
+        else
+            gz_offset = gz_offset - mean_gz / (gyro_deadzone + 1);
 
         printf("Number of ready axes: %d\r\n", ready);
 
-        if (ready==6) break;
+        if (ready == 6) break;
     }
 }

--- a/src/hw-test/test-imu-calibration.cpp
+++ b/src/hw-test/test-imu-calibration.cpp
@@ -40,7 +40,9 @@ void calibration();
 
 Serial pc(RJ_SERIAL_RXTX);
 
-MPU6050 imu(MPU6050_DEFAULT_ADDRESS, RJ_I2C_SDA, RJ_I2C_SCL);
+
+std::shared_ptr<SharedI2C> shared_i2c = make_shared<SharedI2C>(RJ_I2C_SDA, RJ_I2C_SCL, RJ_I2C_FREQ);
+MPU6050 imu(shared_i2c, MPU6050_DEFAULT_ADDRESS);
 LocalFileSystem local("local");
 
 int main() {

--- a/src/hw-test/test-imu-calibration.cpp
+++ b/src/hw-test/test-imu-calibration.cpp
@@ -14,7 +14,7 @@
 
 // Amount of readings used to average, make it higher to get more precision but 
 // program will be slower  (default:1000)
-int buffer_size = 10000;
+int buffer_size = 1000;
 // Accelerometer error allowed, make it lower to get more precision, but may
 // not converge  (default:8)
 int accel_deadzone = 8;
@@ -122,7 +122,7 @@ void sample(){
     long buff_ax = 0, buff_ay = 0, buff_az = 0,
          buff_gx = 0, buff_gy = 0, buff_gz = 0;
 
-    const int skip_dst = 1000;
+    const int skip_dst = 100;
 
     while (i < (buffer_size + skip_dst + 1)) {
         // read raw accel/gyro measurements from device

--- a/src/hw-test/test-imu-calibration.cpp
+++ b/src/hw-test/test-imu-calibration.cpp
@@ -14,7 +14,7 @@
 
 // Amount of readings used to average, make it higher to get more precision but 
 // program will be slower  (default:1000)
-int buffer_size = 1000;
+int buffer_size = 10000;
 // Accelerometer error allowed, make it lower to get more precision, but may
 // not converge  (default:8)
 int accel_deadzone = 8;
@@ -122,7 +122,7 @@ void sample(){
     long buff_ax = 0, buff_ay = 0, buff_az = 0,
          buff_gx = 0, buff_gy = 0, buff_gz = 0;
 
-    const int skip_dst = 100;
+    const int skip_dst = 1000;
 
     while (i < (buffer_size + skip_dst + 1)) {
         // read raw accel/gyro measurements from device

--- a/src/hw-test/test-imu.cpp
+++ b/src/hw-test/test-imu.cpp
@@ -17,20 +17,24 @@ bool batchedResult = false;
 std::vector<unsigned int> freq1;
 std::vector<unsigned int> freq2;
 
-int buffersize=1000;     //Amount of readings used to average, make it higher to get more precision but sketch will be slower  (default:1000)
-int acel_deadzone=8;     //Acelerometer error allowed, make it lower to get more precision, but sketch may not converge  (default:8)
-int giro_deadzone=1;     //Giro error allowed, make it lower to get more precision, but sketch may not converge  (default:1)
+int buffersize = 1000;  // Amount of readings used to average, make it higher to
+                        // get more precision but sketch will be slower
+                        // (default:1000)
+int acel_deadzone = 8;  // Acelerometer error allowed, make it lower to get more
+                        // precision, but sketch may not converge  (default:8)
+int giro_deadzone = 1;  // Giro error allowed, make it lower to get more
+                        // precision, but sketch may not converge  (default:1)
 
-int16_t ax = 0, ay = 0, az = 0,
-        gx = 0, gy = 0, gz = 0;
+int16_t ax = 0, ay = 0, az = 0, gx = 0, gy = 0, gz = 0;
 
-int mean_ax = 0, mean_ay = 0, mean_az = 0,
-    mean_gx = 0, mean_gy = 0, mean_gz = 0;
+int mean_ax = 0, mean_ay = 0, mean_az = 0, mean_gx = 0, mean_gy = 0,
+    mean_gz = 0;
 
-int ax_offset = 0, ay_offset = 0, az_offset = 0,
-    gx_offset = 0, gy_offset = 0, gz_offset = 0;
+int ax_offset = 0, ay_offset = 0, az_offset = 0, gx_offset = 0, gy_offset = 0,
+    gz_offset = 0;
 
-std::shared_ptr<SharedI2C> shared_i2c = make_shared<SharedI2C>(RJ_I2C_SDA, RJ_I2C_SCL, RJ_I2C_FREQ);
+std::shared_ptr<SharedI2C> shared_i2c =
+    make_shared<SharedI2C>(RJ_I2C_SDA, RJ_I2C_SCL, RJ_I2C_FREQ);
 MPU6050 imu(shared_i2c, MPU6050_DEFAULT_ADDRESS);
 
 Serial pc(RJ_SERIAL_RXTX);
@@ -43,15 +47,17 @@ int main() {
     printf("Starting.\r\n");
 
     imu.initialize();
-    
+
     int success = 0;
 
-    FILE *fp = fopen("/local/offsets.txt", "r");  // Open "out.txt" on the local file system for writing
+    FILE* fp =
+        fopen("/local/offsets.txt",
+              "r");  // Open "out.txt" on the local file system for writing
 
     printf("open\r\n");
     if (fp != nullptr) {
-        success = fscanf(fp, "%d %d %d %d %d %d", &ax_offset, &ay_offset, &az_offset,
-                                                  &gx_offset, &gy_offset, &gz_offset);
+        success = fscanf(fp, "%d %d %d %d %d %d", &ax_offset, &ay_offset,
+                         &az_offset, &gx_offset, &gy_offset, &gz_offset);
         printf("fscanf done\r\n");
         fclose(fp);
         printf("closed\r\n");
@@ -70,7 +76,8 @@ int main() {
     if (success == 6) {
         printf("Successfully imported offsets from offsets.txt\r\n");
     } else {
-        printf("Failed to import offsets from offsets.txt, defaulting to 0\r\n");
+        printf(
+            "Failed to import offsets from offsets.txt, defaulting to 0\r\n");
     }
 
     Thread::wait(2000);

--- a/src/hw-test/test-imu.cpp
+++ b/src/hw-test/test-imu.cpp
@@ -30,7 +30,8 @@ int mean_ax = 0, mean_ay = 0, mean_az = 0,
 int ax_offset = 0, ay_offset = 0, az_offset = 0,
     gx_offset = 0, gy_offset = 0, gz_offset = 0;
 
-MPU6050 imu(MPU6050_DEFAULT_ADDRESS, RJ_I2C_SDA, RJ_I2C_SCL);
+std::shared_ptr<SharedI2C> shared_i2c = make_shared<SharedI2C>(RJ_I2C_SDA, RJ_I2C_SCL, RJ_I2C_FREQ);
+MPU6050 imu(shared_i2c, MPU6050_DEFAULT_ADDRESS);
 
 Serial pc(RJ_SERIAL_RXTX);
 

--- a/src/hw-test/test-led.cpp
+++ b/src/hw-test/test-led.cpp
@@ -10,7 +10,8 @@
 // For some reason, the linker fails if there is no call to Thread::wait()...
 void fix() { Thread::wait(1); }
 
-std::shared_ptr<SharedI2C> shared_i2c = make_shared<SharedI2C>(RJ_I2C_SDA, RJ_I2C_SCL, RJ_I2C_FREQ);
+std::shared_ptr<SharedI2C> shared_i2c =
+    make_shared<SharedI2C>(RJ_I2C_SDA, RJ_I2C_SCL, RJ_I2C_FREQ);
 
 /*
  * This demo program lights up an error led on the control board corresponding

--- a/src/hw-test/test-led.cpp
+++ b/src/hw-test/test-led.cpp
@@ -10,6 +10,8 @@
 // For some reason, the linker fails if there is no call to Thread::wait()...
 void fix() { Thread::wait(1); }
 
+std::shared_ptr<SharedI2C> shared_i2c = make_shared<SharedI2C>(RJ_I2C_SDA, RJ_I2C_SCL, RJ_I2C_FREQ);
+
 /*
  * This demo program lights up an error led on the control board corresponding
  * to the positin of the rotary selector (shell id dial).  The rotary selector
@@ -24,7 +26,7 @@ int main(int argc, char** argv) {
     // Init IO Expander and turn all LEDs on.  The first parameter to config()
     // sets the first 8 lines to input and the last 8 to output.  The pullup
     // resistors and polarity swap are enabled for the 4 rotary selector lines.
-    MCP23017 ioExpander(RJ_I2C_SDA, RJ_I2C_SCL, RJ_IO_EXPANDER_I2C_ADDRESS);
+    MCP23017 ioExpander(shared_i2c, RJ_IO_EXPANDER_I2C_ADDRESS);
     ioExpander.config(0x00FF, 0x00f0, 0x00f0);
     ioExpander.writeMask((uint16_t)~IOExpanderErrorLEDMask,
                          IOExpanderErrorLEDMask);


### PR DESCRIPTION
This PR adds our first IMU integration in firmware. We use the rotational velocity measurement from the gyro to stabilize our bot's rotation when soccer is commanding little or no rotational velocity itself.

Nothing has changed about the command packet structure, and this only activates when we are trying to strafe or otherwise move without intentional rotation. Further PRs will likely move all rotation control to the bot itself, and send world velocities rather than body relative so the bot's faster inner control loop can handle divergences from that much more quickly.

**Operation Changes**:
The IMU requires calibration to function without drift. A calibration test program is already in our repo and can be compiled + flashed using `make robot-test-imu-calibration-prog`. This will write a one line file with 6 offsets to `offsets.txt` on the mbed's file system, which will in turn be read on start up the the control board firmware.

**Related Issues**:
- @guyfleeman refactored the way I2C is handled to avoid thread safety issues in this branch
- For some reason, when this branch is compiled on 16.04 or other, newer versions of the arm toolcahin (like on Arch), the binaries produced segfault regularly.
- File system IO was causing segfaults in the PidMotionController's constructor or ControllerTaskThread's initialization. Therefore it was moved into main and passed all the way through.