### PR TITLE
LEDModule update

### DIFF
--- a/robot/control/Inc/MicroPackets.hpp
+++ b/robot/control/Inc/MicroPackets.hpp
@@ -110,7 +110,6 @@ struct RadioError {
     bool initialized = false; /**< Stores whether Radio has been initialized */
     uint32_t lastUpdate;      /**< Time at which RadioError was last updated (milliseconds) */
 
-    bool hasError;                 /**< Stores whether Radio has an error */
     bool hasConnectionError;       /**< Stores if Radio is having trouble connecting to WiFi */
     bool hasSoccerConnectionError; /**< Stores if Radio is having trouble communicating with Soccer */
 };

--- a/robot/control/Inc/MicroPackets.hpp
+++ b/robot/control/Inc/MicroPackets.hpp
@@ -110,8 +110,9 @@ struct RadioError {
     bool initialized = false; /**< Stores whether Radio has been initialized */
     uint32_t lastUpdate;      /**< Time at which RadioError was last updated (milliseconds) */
 
-    bool hasError;            /**< Stores whether Radio has an error */
-    bool hasConnectionError;   /**< Stores if Radio is having trouble connecting to WiFi */
+    bool hasError;                 /**< Stores whether Radio has an error */
+    bool hasConnectionError;       /**< Stores if Radio is having trouble connecting to WiFi */
+    bool hasSoccerConnectionError; /**< Stores if Radio is having trouble communicating with Soccer */
 };
 
 /** @struct RobotID

--- a/robot/control/Inc/MicroPackets.hpp
+++ b/robot/control/Inc/MicroPackets.hpp
@@ -111,6 +111,7 @@ struct RadioError {
     uint32_t lastUpdate;      /**< Time at which RadioError was last updated (milliseconds) */
 
     bool hasError;            /**< Stores whether Radio has an error */
+    bool hasConnectionError;   /**< Stores if Radio is having trouble connecting to WiFi */
 };
 
 /** @struct RobotID

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -42,7 +42,9 @@ enum errorColors_1 : uint32_t {
  */
 enum errorColors_2 : uint32_t {
     RADIO_BOOT_FAIL = 0x0000FF, // RED
-    RADIO_CONN_WIFI_FAIL = 0x0080FF  // ORANGE
+    RADIO_CONN_WIFI_FAIL = 0x0080FF,  // ORANGE
+    KICKER_BOOT_FAIL = 0x000FF, // RED
+    FPGA_BOOT_FAIL = 0x000FF // RED
 };
 
 /**
@@ -202,7 +204,12 @@ private:
     const struct Error ERR_RADIO_CONN_FAIL = {errorColors_0::RADIO_ERROR,
                                               errorColors_1::FATAL,
                                               errorColors_2::RADIO_CONN_WIFI_FAIL};
-
+    const struct Error ERR_KICKER_BOOT_FAIL = {errorColors_0::KICKER_ERROR,
+                                               errorColors_1::FATAL,
+                                               errorColors_2::KICKER_BOOT_FAIL};
+    const struct Error ERR_FPGA_BOOT_FAIL = {errorColors_0::FPGA_ERROR,
+                                             errorColors_1::FATAL,
+                                             errorColors_2::FPGA_BOOT_FAIL};
 
     /**
      * Vector of colors for dotStars to display sequentially based on current errors

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <memory>
 #include <vector>
@@ -40,14 +41,14 @@ enum errorColors_1 : uint32_t {
  * Third LED in error display format: Category / Level / Info
  */
 enum errorColors_2 : uint32_t {
-    RADIO_BOOT_FAIL = 0x0000FF // RED
+    RADIO_BOOT_FAIL = 0x0000FF, // RED
+    RADIO_CONN_FAIL = 0x0080FF // ORANGE
 };
 
 /**
  * Struct to store error names and LED values in colorQueue
  */
 struct Error {
-    const std::string name;
     const uint32_t led0;
     const uint32_t led1;
     const uint32_t led2;
@@ -176,12 +177,12 @@ private:
     /**
      * Add error to colorQueue
      */
-    void addError(Error e);
+    void addError(Error newError);
 
     /**
      * Remove error from colorQueue
      */
-    void removeError(std::string name);
+    void removeError(Error error);
 
     const static uint16_t IOExpanderErrorLEDMask = 0xFF00;
 
@@ -194,6 +195,10 @@ private:
     LockedStruct<RadioError>& radioError;
 
     DigitalOut dotStarNCS;
+
+    const struct Error ERR_RADIO_BOOT_FAIL = {errorColors_0::RADIO_ERROR, errorColors_1::FATAL, errorColors_2::RADIO_BOOT_FAIL};
+    const struct Error ERR_RADIO_CONN_FAIL = {errorColors_0::RADIO_ERROR, errorColors_1::FATAL, errorColors_2::RADIO_CONN_FAIL};
+
 
     /**
      * Vector of colors for dotStars to display sequentially based on current errors

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -233,7 +233,7 @@ private:
     std::vector<Error> colorQueue;
 
     /**
-     * Current index of displayed color
+     * Current index of colorQueue
      */
     size_t index = 0;
 

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -18,10 +18,10 @@
  * First LED in error display format: Category / Level / Info
  */
 enum errorColors_0 : uint32_t {
-    RADIO_ERROR = 0x0080FF;  // ORANGE
-    IMU_ERROR = 0x00FFFF;    // YELLOW
-    KICKER_ERROR = 0x00FF00; // GREEN
-    FPGA_ERROR = 0xFF0000;   // BLUE
+    RADIO_ERROR = 0x0080FF,  // ORANGE
+    IMU_ERROR = 0x00FFFF,    // YELLOW
+    KICKER_ERROR = 0x00FF00, // GREEN
+    FPGA_ERROR = 0xFF0000   // BLUE
 };
 
 /**
@@ -29,10 +29,10 @@ enum errorColors_0 : uint32_t {
  * Second LED in error display format: Category / Level / Info
  */
 enum errorColors_1 : uint32_t {
-    FATAL = 0x0000FF; // RED
-    ERROR = 0x0080FF; // ORANGE
-    WARN = 0xFFFF00;  // YELLOW
-    INFO = 0xFF0000;  // BLUE
+    FATAL = 0x0000FF, // RED
+    ERROR = 0x0080FF, // ORANGE
+    WARN = 0xFFFF00,  // YELLOW
+    INFO = 0xFF0000,  // BLUE
 };
 
 /**
@@ -40,7 +40,7 @@ enum errorColors_1 : uint32_t {
  * Third LED in error display format: Category / Level / Info
  */
 enum errorColors_2 : uint32_t {
-    RADIO_BOOT_FAIL = 0x0000FF; // RED
+    RADIO_BOOT_FAIL = 0x0000FF // RED
 };
 
 /**
@@ -50,6 +50,7 @@ struct Error {
     const std::string name;
     const uint32_t led0;
     const uint32_t led1;
+    const uint32_t led2;
 };
 
 /**
@@ -148,7 +149,7 @@ public:
 
 private:
     /**
-     * Sets the color of the two dot stars
+     * Sets the color of the three dot stars
      *
      * @param led0 0..7 red
      *             8..15 green
@@ -159,8 +160,13 @@ private:
      *             8..15 green
      *             16..23 blue
      *             24..31 don't care
+     *
+     * @param led1 0..7 red
+     *             8..15 green
+     *             16..23 blue
+     *             24..31 don't care
      */
-    void setColor(uint32_t led0, uint32_t led1);
+    void setColor(uint32_t led0, uint32_t led1, uint32_t led2);
 
     /**
      * Cycle through error color codes to display
@@ -175,7 +181,7 @@ private:
     /**
      * Remove error from colorQueue
      */
-    void removeError(std::string name)
+    void removeError(std::string name);
 
     const static uint16_t IOExpanderErrorLEDMask = 0xFF00;
 

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -12,6 +12,12 @@
 #include "MicroPackets.hpp"
 #include "drivers/MCP23017.hpp"
 
+struct Error {
+    const std::string name;
+    const uint32_t led0;
+    const uint32_t led1;
+};
+
 /**
  * Module interfacing with debugging LEDS based on the statuses of other electronics
  */
@@ -130,7 +136,12 @@ private:
     /**
      * Add error to colorQueue
      */
-    void addError(uint32_t led0, uint32_t led1);
+    void addError(Error e);
+
+    /**
+     * Remove error from colorQueue
+     */
+    void removeError(std::string name)
 
     const static uint16_t IOExpanderErrorLEDMask = 0xFF00;
 
@@ -147,7 +158,7 @@ private:
     /**
      * Vector of colors for dotStars to display sequentially based on current errors
      */
-    std::vector<std::array<std::uint32_t, 2>> colorQueue;
+    std::vector<Error> colorQueue;
 
     /**
      * Current index of displayed color

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -176,14 +176,9 @@ private:
     void displayErrors();
 
     /**
-     * Add error to colorQueue
+     * Toggle error in errToggles
      */
-    void addError(Error newError);
-
-    /**
-     * Remove error from colorQueue
-     */
-    void removeError(Error error);
+    void setError(const Error e, bool toggle);
 
     const static uint16_t IOExpanderErrorLEDMask = 0xFF00;
 
@@ -222,14 +217,20 @@ private:
                                              errorColors_1::FATAL,
                                              errorColors_2::BOOT_FAIL};
 
+    const std::array<Error, 6> ERR_LIST = {ERR_RADIO_BOOT_FAIL,
+                                               ERR_RADIO_WIFI_FAIL,
+                                               ERR_RADIO_SOCCER_FAIL,
+                                               ERR_FPGA_BOOT_FAIL,
+                                               ERR_KICKER_BOOT_FAIL,
+                                               ERR_IMU_BOOT_FAIL};
 
     /**
-     * Vector of colors for dotStars to display sequentially based on current errors
+     * Array of toggles whose values indicates where the error at the same index in ERR_LIST is active or not
      */
-    std::vector<Error> colorQueue;
+    std::array<bool, 6> errToggles;
 
     /**
-     * Current index of colorQueue
+     * Current index of errToggles
      */
     size_t index = 0;
 

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -127,6 +127,11 @@ private:
      */
     void displayErrors();
 
+    /**
+     * Add error to colorQueue
+     */
+    void addError(uint32_t led0, uint32_t led1);
+
     const static uint16_t IOExpanderErrorLEDMask = 0xFF00;
 
     LockedStruct<MCP23017>& ioExpander;
@@ -147,7 +152,24 @@ private:
     /**
      * Current index of displayed color
      */
-    int index;
+    int index = 0;
+
+    /**
+     * Number of frames (1/kPeriod seconds) for which the error lights will be on, to cycle through error LEDs
+     */
+    int framesOn = 2;
+    int framesOnCounter = 0;
+
+    /**
+     * Number of frames (1/kPeriod seconds) for which the error lights will be off, to cycle through error LEDs
+     */
+    int framesOff = 3;
+    int framesOffCounter = 0;
+
+    /**
+     * Toggles whether dotStar LEDs are on or off for blinking between errors
+     */
+    bool lightsOn = true;
 
     /**
      * Array of mTrain LEDs as `DigitalOut`s

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -50,7 +50,7 @@ enum errorColors_2 : uint32_t {
 };
 
 /**
- * Struct to store error names and LED values in colorQueue
+ * Struct to store LED values in colorQueue
  */
 struct Error {
     uint32_t led0;
@@ -114,28 +114,24 @@ public:
     /**
      * Toggles LEDs to signal fpga initialization
      * - mTrain LED1 turned on
-     * - dotstars set to [yellow, white]
      */
     void fpgaInitialized();
 
     /**
      * Toggles LEDs to signal radio initialization
      * - mTrain LED2 turned on
-     * - dotstars set to [pink, white]
      */
     void radioInitialized();
 
     /**
      * Toggles LEDs to signal fpga initialization
      * - mTrain LED3 turned on
-     * - dotstars set to [blue, white]
      */
     void kickerInitialized();
 
     /**
      * Toggles LEDs to signal full system initialization
      * - mTrain LED4 turned on
-     * - dotstars set to [green, green]
      */
     void fullyInitialized();
 
@@ -147,7 +143,7 @@ public:
     void missedSuperLoop();
 
     /**
-     * Specific toggling pattern for missing a module run X times in a row
+     * Set specific toggling pattern for missing a module run X times in a row
      *
      * mTrain LED 3 toggles opposite of LEDs 2 and 4, indicating that due to priority and timing, some module never runs
      */
@@ -167,7 +163,7 @@ private:
      *             16..23 blue
      *             24..31 don't care
      *
-     * @param led1 0..7 red
+     * @param led2 0..7 red
      *             8..15 green
      *             16..23 blue
      *             24..31 don't care

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -33,7 +33,7 @@ enum errorColors_1 : uint32_t {
     FATAL = 0x0000FF, // RED
     ERR = 0x0080FF, // ORANGE
     WARN = 0xFFFF00,  // YELLOW
-    INFO = 0xFF0000,  // BLUE
+    INFO = 0xFF0000  // BLUE
 };
 
 /**
@@ -43,6 +43,7 @@ enum errorColors_1 : uint32_t {
 enum errorColors_2 : uint32_t {
     RADIO_BOOT_FAIL = 0x0000FF, // RED
     RADIO_CONN_WIFI_FAIL = 0x0080FF,  // ORANGE
+    RADIO_CONN_SOCCER_FAIL = 0x00FFFF, // YELLOW
     KICKER_BOOT_FAIL = 0x000FF, // RED
     FPGA_BOOT_FAIL = 0x000FF // RED
 };
@@ -201,9 +202,12 @@ private:
     const struct Error ERR_RADIO_BOOT_FAIL = {errorColors_0::RADIO_ERROR,
                                               errorColors_1::FATAL,
                                               errorColors_2::RADIO_BOOT_FAIL};
-    const struct Error ERR_RADIO_CONN_FAIL = {errorColors_0::RADIO_ERROR,
+    const struct Error ERR_RADIO_WIFI_FAIL = {errorColors_0::RADIO_ERROR,
                                               errorColors_1::FATAL,
                                               errorColors_2::RADIO_CONN_WIFI_FAIL};
+    const struct Error ERR_RADIO_SOCCER_FAIL = {errorColors_0::RADIO_ERROR,
+                                                errorColors_1::FATAL,
+                                                errorColors_2::RADIO_CONN_SOCCER_FAIL};
     const struct Error ERR_KICKER_BOOT_FAIL = {errorColors_0::KICKER_ERROR,
                                                errorColors_1::FATAL,
                                                errorColors_2::KICKER_BOOT_FAIL};

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -237,13 +237,13 @@ private:
     /**
      * Number of frames (1/kPeriod seconds) for which the error lights will be on, to cycle through error LEDs
      */
-    int framesOn = 2;
+    int framesOn = 20;
     int framesOnCounter = 0;
 
     /**
      * Number of frames (1/kPeriod seconds) for which the error lights will be off, to cycle through error LEDs
      */
-    int framesOff = 3;
+    int framesOff = 10;
     int framesOffCounter = 0;
 
     /**

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -31,7 +31,7 @@ enum errorColors_0 : uint32_t {
  */
 enum errorColors_1 : uint32_t {
     FATAL = 0x0000FF, // RED
-    ERROR = 0x0080FF, // ORANGE
+    ERR = 0x0080FF, // ORANGE
     WARN = 0xFFFF00,  // YELLOW
     INFO = 0xFF0000,  // BLUE
 };
@@ -42,16 +42,16 @@ enum errorColors_1 : uint32_t {
  */
 enum errorColors_2 : uint32_t {
     RADIO_BOOT_FAIL = 0x0000FF, // RED
-    RADIO_CONN_FAIL = 0x0080FF // ORANGE
+    RADIO_CONN_WIFI_FAIL = 0x0080FF  // ORANGE
 };
 
 /**
  * Struct to store error names and LED values in colorQueue
  */
 struct Error {
-    const uint32_t led0;
-    const uint32_t led1;
-    const uint32_t led2;
+    uint32_t led0;
+    uint32_t led1;
+    uint32_t led2;
 };
 
 /**
@@ -196,8 +196,12 @@ private:
 
     DigitalOut dotStarNCS;
 
-    const struct Error ERR_RADIO_BOOT_FAIL = {errorColors_0::RADIO_ERROR, errorColors_1::FATAL, errorColors_2::RADIO_BOOT_FAIL};
-    const struct Error ERR_RADIO_CONN_FAIL = {errorColors_0::RADIO_ERROR, errorColors_1::FATAL, errorColors_2::RADIO_CONN_FAIL};
+    const struct Error ERR_RADIO_BOOT_FAIL = {errorColors_0::RADIO_ERROR,
+                                              errorColors_1::FATAL,
+                                              errorColors_2::RADIO_BOOT_FAIL};
+    const struct Error ERR_RADIO_CONN_FAIL = {errorColors_0::RADIO_ERROR,
+                                              errorColors_1::FATAL,
+                                              errorColors_2::RADIO_CONN_WIFI_FAIL};
 
 
     /**
@@ -208,7 +212,7 @@ private:
     /**
      * Current index of displayed color
      */
-    int index = 0;
+    size_t index = 0;
 
     /**
      * Number of frames (1/kPeriod seconds) for which the error lights will be on, to cycle through error LEDs

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -18,7 +18,7 @@
  * Constants for DotStar LEDs (BGR)
  * First LED in error display format: Category / Level / Info
  */
-enum errorColors_0 : uint32_t {
+enum CategoryColors : uint32_t {
     RADIO_ERROR = 0x0080FF,  // ORANGE
     FPGA_ERROR = 0x00FFFF,    // YELLOW
     KICKER_ERROR = 0x00FF00, // GREEN
@@ -29,7 +29,7 @@ enum errorColors_0 : uint32_t {
  * Constants for DotStar LEDs (BGR)
  * Second LED in error display format: Category / Level / Info
  */
-enum errorColors_1 : uint32_t {
+enum LevelColors : uint32_t {
     FATAL = 0x0000FF, // RED
     ERR = 0x0080FF, // ORANGE
     WARN = 0xFFFF00,  // YELLOW
@@ -40,7 +40,7 @@ enum errorColors_1 : uint32_t {
  * Constants for DotStar LEDs (BGR)
  * Third LED in error display format: Category / Level / Info
  */
-enum errorColors_2 : uint32_t {
+enum InfoColors : uint32_t {
     // GENERAL
     BOOT_FAIL = 0x0000FF,  // RED
 
@@ -50,7 +50,7 @@ enum errorColors_2 : uint32_t {
 };
 
 /**
- * Struct to store LED values in colorQueue
+ * Struct to store LED values in ERR_LIST
  */
 struct Error {
     uint32_t led0;
@@ -194,28 +194,28 @@ private:
     DigitalOut dotStarNCS;
 
     // RADIO
-    const struct Error ERR_RADIO_BOOT_FAIL = {errorColors_0::RADIO_ERROR,
-                                              errorColors_1::FATAL,
-                                              errorColors_2::BOOT_FAIL};
-    const struct Error ERR_RADIO_WIFI_FAIL = {errorColors_0::RADIO_ERROR,
-                                              errorColors_1::FATAL,
-                                              errorColors_2::RADIO_CONN_WIFI_FAIL};
-    const struct Error ERR_RADIO_SOCCER_FAIL = {errorColors_0::RADIO_ERROR,
-                                                errorColors_1::FATAL,
-                                                errorColors_2::RADIO_CONN_SOCCER_FAIL};
+    const struct Error ERR_RADIO_BOOT_FAIL = {CategoryColors::RADIO_ERROR,
+                                              LevelColors::FATAL,
+                                              InfoColors::BOOT_FAIL};
+    const struct Error ERR_RADIO_WIFI_FAIL = {CategoryColors::RADIO_ERROR,
+                                              LevelColors::FATAL,
+                                              InfoColors::RADIO_CONN_WIFI_FAIL};
+    const struct Error ERR_RADIO_SOCCER_FAIL = {CategoryColors::RADIO_ERROR,
+                                                LevelColors::FATAL,
+                                                InfoColors::RADIO_CONN_SOCCER_FAIL};
     // FPGA
-    const struct Error ERR_FPGA_BOOT_FAIL = {errorColors_0::FPGA_ERROR,
-                                             errorColors_1::FATAL,
-                                             errorColors_2::BOOT_FAIL};
+    const struct Error ERR_FPGA_BOOT_FAIL = {CategoryColors::FPGA_ERROR,
+                                             LevelColors::FATAL,
+                                             InfoColors::BOOT_FAIL};
 
     // KICKER
-    const struct Error ERR_KICKER_BOOT_FAIL = {errorColors_0::KICKER_ERROR,
-                                               errorColors_1::FATAL,
-                                               errorColors_2::BOOT_FAIL};
+    const struct Error ERR_KICKER_BOOT_FAIL = {CategoryColors::KICKER_ERROR,
+                                               LevelColors::FATAL,
+                                               InfoColors::BOOT_FAIL};
     // IMU
-    const struct Error ERR_IMU_BOOT_FAIL =  {errorColors_0::IMU_ERROR,
-                                             errorColors_1::FATAL,
-                                             errorColors_2::BOOT_FAIL};
+    const struct Error ERR_IMU_BOOT_FAIL =  {CategoryColors::IMU_ERROR,
+                                             LevelColors::FATAL,
+                                             InfoColors::BOOT_FAIL};
 
     const std::array<Error, 6> ERR_LIST = {ERR_RADIO_BOOT_FAIL,
                                                ERR_RADIO_WIFI_FAIL,

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <memory>
+#include <vector>
 
 #include "LockedStruct.hpp"
 #include "DigitalOut.hpp"
@@ -121,6 +122,11 @@ private:
      */
     void setColor(uint32_t led0, uint32_t led1);
 
+    /**
+     * Cycle through error color codes to display
+     */
+    void displayErrors();
+
     const static uint16_t IOExpanderErrorLEDMask = 0xFF00;
 
     LockedStruct<MCP23017>& ioExpander;
@@ -132,6 +138,16 @@ private:
     LockedStruct<RadioError>& radioError;
 
     DigitalOut dotStarNCS;
+
+    /**
+     * Vector of colors for dotStars to display sequentially based on current errors
+     */
+    std::vector<std::array<std::uint32_t, 2>> colorQueue;
+
+    /**
+     * Current index of displayed color
+     */
+    int index;
 
     /**
      * Array of mTrain LEDs as `DigitalOut`s

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -20,9 +20,9 @@
  */
 enum errorColors_0 : uint32_t {
     RADIO_ERROR = 0x0080FF,  // ORANGE
-    IMU_ERROR = 0x00FFFF,    // YELLOW
+    FPGA_ERROR = 0x00FFFF,    // YELLOW
     KICKER_ERROR = 0x00FF00, // GREEN
-    FPGA_ERROR = 0xFF0000   // BLUE
+    IMU_ERROR = 0xFF0000   // BLUE
 };
 
 /**
@@ -41,11 +41,12 @@ enum errorColors_1 : uint32_t {
  * Third LED in error display format: Category / Level / Info
  */
 enum errorColors_2 : uint32_t {
-    RADIO_BOOT_FAIL = 0x0000FF, // RED
+    // GENERAL
+    BOOT_FAIL = 0x0000FF,  // RED
+
+    // RADIO
     RADIO_CONN_WIFI_FAIL = 0x0080FF,  // ORANGE
-    RADIO_CONN_SOCCER_FAIL = 0x00FFFF, // YELLOW
-    KICKER_BOOT_FAIL = 0x000FF, // RED
-    FPGA_BOOT_FAIL = 0x000FF // RED
+    RADIO_CONN_SOCCER_FAIL = 0x00FFFF // YELLOW
 };
 
 /**
@@ -94,7 +95,8 @@ public:
               LockedStruct<BatteryVoltage>& batteryVoltage,
               LockedStruct<FPGAStatus>& fpgaStatus,
               LockedStruct<KickerInfo>& kickerInfo,
-              LockedStruct<RadioError>& radioError);
+              LockedStruct<RadioError>& radioError,
+              LockedStruct<IMUData>& imuData);
 
     /**
      * Code which initializes module
@@ -196,24 +198,34 @@ private:
     LockedStruct<FPGAStatus>& fpgaStatus;
     LockedStruct<KickerInfo>& kickerInfo;
     LockedStruct<RadioError>& radioError;
+    LockedStruct<IMUData>& imuData;
 
     DigitalOut dotStarNCS;
 
+    // RADIO
     const struct Error ERR_RADIO_BOOT_FAIL = {errorColors_0::RADIO_ERROR,
                                               errorColors_1::FATAL,
-                                              errorColors_2::RADIO_BOOT_FAIL};
+                                              errorColors_2::BOOT_FAIL};
     const struct Error ERR_RADIO_WIFI_FAIL = {errorColors_0::RADIO_ERROR,
                                               errorColors_1::FATAL,
                                               errorColors_2::RADIO_CONN_WIFI_FAIL};
     const struct Error ERR_RADIO_SOCCER_FAIL = {errorColors_0::RADIO_ERROR,
                                                 errorColors_1::FATAL,
                                                 errorColors_2::RADIO_CONN_SOCCER_FAIL};
-    const struct Error ERR_KICKER_BOOT_FAIL = {errorColors_0::KICKER_ERROR,
-                                               errorColors_1::FATAL,
-                                               errorColors_2::KICKER_BOOT_FAIL};
+    // FPGA
     const struct Error ERR_FPGA_BOOT_FAIL = {errorColors_0::FPGA_ERROR,
                                              errorColors_1::FATAL,
-                                             errorColors_2::FPGA_BOOT_FAIL};
+                                             errorColors_2::BOOT_FAIL};
+
+    // KICKER
+    const struct Error ERR_KICKER_BOOT_FAIL = {errorColors_0::KICKER_ERROR,
+                                               errorColors_1::FATAL,
+                                               errorColors_2::BOOT_FAIL};
+    // IMU
+    const struct Error ERR_IMU_BOOT_FAIL =  {errorColors_0::IMU_ERROR,
+                                             errorColors_1::FATAL,
+                                             errorColors_2::BOOT_FAIL};
+
 
     /**
      * Vector of colors for dotStars to display sequentially based on current errors

--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -12,6 +12,40 @@
 #include "MicroPackets.hpp"
 #include "drivers/MCP23017.hpp"
 
+
+/**
+ * Constants for DotStar LEDs (BGR)
+ * First LED in error display format: Category / Level / Info
+ */
+enum errorColors_0 : uint32_t {
+    RADIO_ERROR = 0x0080FF;  // ORANGE
+    IMU_ERROR = 0x00FFFF;    // YELLOW
+    KICKER_ERROR = 0x00FF00; // GREEN
+    FPGA_ERROR = 0xFF0000;   // BLUE
+};
+
+/**
+ * Constants for DotStar LEDs (BGR)
+ * Second LED in error display format: Category / Level / Info
+ */
+enum errorColors_1 : uint32_t {
+    FATAL = 0x0000FF; // RED
+    ERROR = 0x0080FF; // ORANGE
+    WARN = 0xFFFF00;  // YELLOW
+    INFO = 0xFF0000;  // BLUE
+};
+
+/**
+ * Constants for DotStar LEDs (BGR)
+ * Third LED in error display format: Category / Level / Info
+ */
+enum errorColors_2 : uint32_t {
+    RADIO_BOOT_FAIL = 0x0000FF; // RED
+};
+
+/**
+ * Struct to store error names and LED values in colorQueue
+ */
 struct Error {
     const std::string name;
     const uint32_t led0;

--- a/robot/control/Inc/modules/RotaryDialModule.hpp
+++ b/robot/control/Inc/modules/RotaryDialModule.hpp
@@ -15,7 +15,7 @@ public:
     /**
      * Number of times per second (frequency) that RotaryDialModule should run (Hz)
      */
-    static constexpr float kFrequency = 1.0f
+    static constexpr float kFrequency = 1.0f;
 
     /**
      * Number of seconds elapsed (period) between RotaryDialModule runs (milliseconds)

--- a/robot/control/Inc/radio/RadioLink.hpp
+++ b/robot/control/Inc/radio/RadioLink.hpp
@@ -40,9 +40,9 @@ public:
     bool receive(KickerCommand& kickerCommand,
                  MotionCommand& motionCommand);
 
-    bool isRadioConnected() { return radioConnected; }
-    bool isRadioInitialized() { return radioInitialized;}
-    bool hasSoccerTimedOut() { return (cyclesWithoutPackets > 10);}
+    bool isRadioConnected() { return radio->isConnected(); }
+    bool isRadioInitialized() { return radioInitialized; }
+    bool hasSoccerTimedOut() { return (cyclesWithoutPackets > 10); }
 private:
     std::unique_ptr<GenericRadio> radio;
     bool radioConnected = false;

--- a/robot/control/Inc/radio/RadioLink.hpp
+++ b/robot/control/Inc/radio/RadioLink.hpp
@@ -41,9 +41,11 @@ public:
                  MotionCommand& motionCommand);
 
     bool isRadioConnected() { return radioConnected; }
+    bool isRadioInitialized() { return radioInitialized;}
     bool hasSoccerTimedOut() { return (cyclesWithoutPackets > 10);}
 private:
     std::unique_ptr<GenericRadio> radio;
     bool radioConnected = false;
+    bool radioInitialized = false;
     int cyclesWithoutPackets = 0;
 };

--- a/robot/control/Inc/radio/RadioLink.hpp
+++ b/robot/control/Inc/radio/RadioLink.hpp
@@ -41,8 +41,9 @@ public:
                  MotionCommand& motionCommand);
 
     bool isRadioConnected() { return radioConnected; }
+    bool hasSoccerTimedOut() { return (cyclesWithoutPackets > 10);}
 private:
     std::unique_ptr<GenericRadio> radio;
     bool radioConnected = false;
-
+    int cyclesWithoutPackets = 0;
 };

--- a/robot/control/Inc/radio/RadioLink.hpp
+++ b/robot/control/Inc/radio/RadioLink.hpp
@@ -40,6 +40,9 @@ public:
     bool receive(KickerCommand& kickerCommand,
                  MotionCommand& motionCommand);
 
+    bool isRadioConnected() { return radioConnected; }
 private:
     std::unique_ptr<GenericRadio> radio;
+    bool radioConnected = false;
+
 };

--- a/robot/control/Src/modules/LEDModule.cpp
+++ b/robot/control/Src/modules/LEDModule.cpp
@@ -74,7 +74,7 @@ void LEDModule::entry() {
             setError(ERR_RADIO_BOOT_FAIL, true);
         }
 
-        if (!radioLock->isValid || radioLock->hasError) {
+        if (!radioLock->isValid || radioLock->hasConnectionError || radioLock->hasSoccerConnectionError) {
             errors |= (1 << ERR_LED_RADIO);
         }
 
@@ -215,10 +215,10 @@ void LEDModule::displayErrors() {
 
         // Make sure index loops back if it has reached end of vector
         // Since we know there is at least one error, we can safely use a while loop to find it.
-        index = (index + 1) % errToggles.size();
-        while(!errToggles.at(index)) {
+        do {
             index = (index + 1) % errToggles.size();
         }
+        while(!errToggles.at(index));
 
         Error e = ERR_LIST.at(index);
         setColor(e.led0, e.led1, e.led2);

--- a/robot/control/Src/modules/LEDModule.cpp
+++ b/robot/control/Src/modules/LEDModule.cpp
@@ -22,7 +22,7 @@ void LEDModule::start() {
     auto ioExpanderLock = ioExpander.lock();
     ioExpanderLock->init();
     setColor(0xFFFFFF, 0xFFFFFF);
-
+    index = 0;
     ioExpanderLock->config(0x00FF, 0x00FF, 0x00FF);
     ioExpanderLock->writeMask(static_cast<uint16_t>(~IOExpanderErrorLEDMask), IOExpanderErrorLEDMask);
 }
@@ -87,6 +87,8 @@ void LEDModule::entry() {
     static bool state = true;
     state = !state;
     leds[0].write(state);
+
+    displayErrors();
 }
 
 void LEDModule::fpgaInitialized() {
@@ -168,4 +170,18 @@ void LEDModule::setColor(uint32_t led0, uint32_t led1) {
     dotStarNCS.write(false);
     dotStarSPI.lock()->transmit(data);
     dotStarNCS.write(true);
+}
+
+void displayErrors() {
+    // Check if there are errors to display, else exit
+    if (colorQueue.size() == 0) {
+        return;
+    }
+
+    // Make sure index loops back if it has reached end of vector
+    if (++index > colorQueue.size()-1) {
+        index = 0;
+    }
+    std::array<uint32_t,2> colors = colorQueue.at(index);
+    setColor(colors.at(0), colors.at(1));
 }

--- a/robot/control/Src/modules/LEDModule.cpp
+++ b/robot/control/Src/modules/LEDModule.cpp
@@ -202,7 +202,7 @@ void LEDModule::displayErrors() {
 
 void LEDModule::addError(Error newError) {
     for(Error currentError: colorQueue) {
-        if (currentError.name.compare(newError.name)) {
+        if (currentError.name.compare(newError->name) == 0) {
             return;
         }
     }
@@ -210,8 +210,8 @@ void LEDModule::addError(Error newError) {
 }
 
 void LEDModule::removeError(std::string name) {
-    for(Error currentError: colorQueue) {
-        if (currentError.name.compare(newError.name)) {
+    for(Error &currentError : colorQueue) {
+        if (currentError.name.compare(newError.name) == 0) {
             colorQueue.erase(currentError);
         }
     }

--- a/robot/control/Src/modules/LEDModule.cpp
+++ b/robot/control/Src/modules/LEDModule.cpp
@@ -172,7 +172,7 @@ void LEDModule::setColor(uint32_t led0, uint32_t led1) {
     dotStarNCS.write(true);
 }
 
-void displayErrors() {
+void LEDModule::displayErrors() {
     // Check if there are errors to display, else exit
     if (colorQueue.size() == 0) {
         return;
@@ -183,7 +183,7 @@ void displayErrors() {
         framesOnCounter = 0;
         lightsOn = false;
         setColor(0x000000,0x000000);
-    } else if (lightsOff && framesOff == framesOffCounter)
+    } else if (!lightsOn && framesOff == framesOffCounter)
         // If error lights have been off long enough, switch them back on to next error color
         framesOffCounter = 0;
         lightsOn = true;
@@ -192,15 +192,27 @@ void displayErrors() {
         if (++index > colorQueue.size()-1) {
             index = 0;
         }
-        std::array<uint32_t,2> colors = colorQueue.at(index);
-        setColor(colors.at(0), colors.at(1));
+        Error e = colorQueue.at(index);
+        setColor(e.led0, e.led1);
     } else {
         // Increment frame counters for lights on/off
         lightsOn ? framesOnCounter++ : framesOffCounter++;
     }
 }
 
-void addError(uint32_t led0, uint32_t led1) {
-    std::array<uint32_t, 2> errorColors = {led0, led1};
-    colorQueue.pushBack(errorColors);
+void LEDModule::addError(Error newError) {
+    for(Error currentError: colorQueue) {
+        if (currentError.name.compare(newError.name)) {
+            return;
+        }
+    }
+    colorQueue.pushBack(newError);
+}
+
+void LEDModule::removeError(std::string name) {
+    for(Error currentError: colorQueue) {
+        if (currentError.name.compare(newError.name)) {
+            colorQueue.erase(currentError);
+        }
+    }
 }

--- a/robot/control/Src/modules/LEDModule.cpp
+++ b/robot/control/Src/modules/LEDModule.cpp
@@ -212,12 +212,12 @@ void LEDModule::displayErrors() {
         return;
     }
 
-    if (lightsOn && framesOn == framesOnCounter){
+    if (lightsOn && framesOnCounter >= framesOn){
         // If error lights have been on long enough, switch them off
         framesOnCounter = 0;
         lightsOn = false;
         setColor(0x000000,0x000000, 0x000000);
-    } else if (!lightsOn && framesOff == framesOffCounter) {
+    } else if (!lightsOn && framesOffCounter >= framesOff) {
         // If error lights have been off long enough, switch them back on to next error color
         framesOffCounter = 0;
         lightsOn = true;

--- a/robot/control/Src/modules/LEDModule.cpp
+++ b/robot/control/Src/modules/LEDModule.cpp
@@ -76,9 +76,15 @@ void LEDModule::entry() {
         }
 
         if (radioLock->hasConnectionError) {
-            addError(ERR_RADIO_CONN_FAIL);
+            addError(ERR_RADIO_WIFI_FAIL);
         } else {
-            removeError(ERR_RADIO_CONN_FAIL);
+            removeError(ERR_RADIO_WIFI_FAIL);
+        }
+
+        if (radioLock->hasSoccerConnectionError) {
+            addError(ERR_RADIO_SOCCER_FAIL);
+        } else {
+            removeError(ERR_RADIO_SOCCER_FAIL);
         }
     }
 

--- a/robot/control/Src/modules/LEDModule.cpp
+++ b/robot/control/Src/modules/LEDModule.cpp
@@ -43,6 +43,9 @@ void LEDModule::entry() {
 
         if (fpgaLock->initialized) {
             fpgaInitialized();
+            removeError(ERR_FPGA_BOOT_FAIL);
+        } else {
+            addError(ERR_FPGA_BOOT_FAIL);
         }
 
         if (!fpgaLock->isValid || fpgaLock->FPGAHasError) {
@@ -63,6 +66,9 @@ void LEDModule::entry() {
 
         if (radioLock->initialized) {
             radioInitialized();
+            removeError(ERR_RADIO_BOOT_FAIL);
+        } else {
+            addError(ERR_RADIO_BOOT_FAIL);
         }
 
         if (!radioLock->isValid || radioLock->hasError) {
@@ -71,6 +77,8 @@ void LEDModule::entry() {
 
         if (radioLock->hasConnectionError) {
             addError(ERR_RADIO_CONN_FAIL);
+        } else {
+            removeError(ERR_RADIO_CONN_FAIL);
         }
     }
 
@@ -78,7 +86,10 @@ void LEDModule::entry() {
         auto kickerLock = kickerInfo.lock();
 
         if (kickerLock->initialized) {
-            radioInitialized();
+            kickerInitialized();
+            addError(ERR_KICKER_BOOT_FAIL);
+        } else {
+            removeError(ERR_KICKER_BOOT_FAIL);
         }
 
         if (kickerLock->isValid || kickerLock->kickerHasError) {
@@ -97,25 +108,21 @@ void LEDModule::entry() {
 
 void LEDModule::fpgaInitialized() {
     // neo pixel stuff
-    setColor(0xFFFF00, 0xFFFFFF, 0xFFFFFF);
     leds[0] = 1;
 }
 
 void LEDModule::radioInitialized() {
     // neo pixel stuff
-    setColor(0xFF00FF, 0xFFFFFF, 0xFFFFFF);
     leds[1] = 1;
 }
 
 void LEDModule::kickerInitialized() {
     // neo pixel stuff
-    setColor(0x00FFFF, 0xFFFFFF, 0xFFFFFF);
     leds[2] = 1;
 }
 
 void LEDModule::fullyInitialized() {
     // green neo pixel
-    setColor(0x00FF00, 0x00FF00, 0x00FF00);
     leds[3] = 1;
 }
 

--- a/robot/control/Src/modules/LEDModule.cpp
+++ b/robot/control/Src/modules/LEDModule.cpp
@@ -199,7 +199,7 @@ void LEDModule::setColor(uint32_t led0, uint32_t led1, uint32_t led2) {
 
 void LEDModule::displayErrors() {
     // If there are no errors, then there is no point in displaying anything
-    if (std::find(errToggles.begin(), errToggles.end(), true) == errToggles.end()) {
+    if (std::none_of(errToggles.begin(), errToggles.end(), [](bool b){return b;})) {
         setColor(0x000000, 0x000000, 0x000000);
         return;
     }

--- a/robot/control/Src/modules/LEDModule.cpp
+++ b/robot/control/Src/modules/LEDModule.cpp
@@ -178,10 +178,29 @@ void displayErrors() {
         return;
     }
 
-    // Make sure index loops back if it has reached end of vector
-    if (++index > colorQueue.size()-1) {
-        index = 0;
+    if (lightsOn && framesOn == framesOnCounter){
+        // If error lights have been on long enough, switch them off
+        framesOnCounter = 0;
+        lightsOn = false;
+        setColor(0x000000,0x000000);
+    } else if (lightsOff && framesOff == framesOffCounter)
+        // If error lights have been off long enough, switch them back on to next error color
+        framesOffCounter = 0;
+        lightsOn = true;
+
+        // Make sure index loops back if it has reached end of vector
+        if (++index > colorQueue.size()-1) {
+            index = 0;
+        }
+        std::array<uint32_t,2> colors = colorQueue.at(index);
+        setColor(colors.at(0), colors.at(1));
+    } else {
+        // Increment frame counters for lights on/off
+        lightsOn ? framesOnCounter++ : framesOffCounter++;
     }
-    std::array<uint32_t,2> colors = colorQueue.at(index);
-    setColor(colors.at(0), colors.at(1));
+}
+
+void addError(uint32_t led0, uint32_t led1) {
+    std::array<uint32_t, 2> errorColors = {led0, led1};
+    colorQueue.pushBack(errorColors);
 }

--- a/robot/control/Src/modules/LEDModule.cpp
+++ b/robot/control/Src/modules/LEDModule.cpp
@@ -220,6 +220,11 @@ void LEDModule::addError(Error newError) {
     colorQueue.push_back(newError);
 }
 
-void LEDModule::removeError(Error error) {
-    colorQueue.erase(std::remove(colorQueue.begin(), colorQueue.end(), error), colorQueue.end());
+void LEDModule::removeError(Error target) {
+    colorQueue.erase(std::remove_if(colorQueue.begin(), colorQueue.end(),
+            [&](Error err) {
+                return err.led0 == target.led0 &&
+                       err.led1 == target.led1 &&
+                       err.led2 == target.led2;
+           }), colorQueue.end());
 }

--- a/robot/control/Src/modules/LEDModule.cpp
+++ b/robot/control/Src/modules/LEDModule.cpp
@@ -150,9 +150,6 @@ void LEDModule::missedSuperLoop() {
     }
 
     missedSuperLoopToggle = !missedSuperLoopToggle;
-
-    // Orange
-    setColor(0x3376DC, 0xFFFFFF, 0xFFFFFF);
 }
 
 void LEDModule::missedModuleRun() {
@@ -165,9 +162,6 @@ void LEDModule::missedModuleRun() {
     }
 
     missedModuleRunToggle = !missedModuleRunToggle;
-
-    // Yellow
-    setColor(0x3FD0F4, 0xFFFFFF, 0xFFFFFF);
 }
 
 void LEDModule::setColor(uint32_t led0, uint32_t led1, uint32_t led2) {

--- a/robot/control/Src/modules/LEDModule.cpp
+++ b/robot/control/Src/modules/LEDModule.cpp
@@ -68,6 +68,10 @@ void LEDModule::entry() {
         if (!radioLock->isValid || radioLock->hasError) {
             errors |= (1 << ERR_LED_RADIO);
         }
+
+        if (radioLock->hasConnectionError) {
+            addError(ERR_RADIO_CONN_FAIL);
+        }
     }
 
     {
@@ -207,17 +211,15 @@ void LEDModule::displayErrors() {
 
 void LEDModule::addError(Error newError) {
     for(Error currentError: colorQueue) {
-        if (currentError.name.compare(newError->name) == 0) {
+        if (currentError.led0 == newError.led0 &&
+            currentError.led1 == newError.led1 &&
+            currentError.led2 == newError.led2) {
             return;
         }
     }
     colorQueue.push_back(newError);
 }
 
-void LEDModule::removeError(std::string name) {
-    for(Error &currentError : colorQueue) {
-        if (currentError.name.compare(newError.name) == 0) {
-            colorQueue.erase(currentError);
-        }
-    }
+void LEDModule::removeError(Error error) {
+    colorQueue.erase(std::remove(colorQueue.begin(), colorQueue.end(), error), colorQueue.end());
 }

--- a/robot/control/Src/modules/RadioModule.cpp
+++ b/robot/control/Src/modules/RadioModule.cpp
@@ -38,6 +38,7 @@ RadioModule::RadioModule(LockedStruct<BatteryVoltage>& batteryVoltage,
     radioErrorLock->lastUpdate = 0;
     radioErrorLock->hasError = false;
     radioErrorLock->hasConnectionError = false;
+    radioErrorLock->hasSoccerConnectionError = false;
 }
 
 void RadioModule::start() {
@@ -80,6 +81,7 @@ void RadioModule::entry() {
         radioErrorLock->isValid = true;
         radioErrorLock->lastUpdate = HAL_GetTick();
         radioErrorLock->hasConnectionError = link.isRadioConnected();
-        radioErrorLock->hasError = radioErrorLock->hasConnectionError;
+        radioErrorLock->hasSoccerConnectionError = link.hasSoccerTimedOut();
+        radioErrorLock->hasError = radioErrorLock->hasConnectionError || radioErrorLock->hasSoccerConnectionError;
     }
 }

--- a/robot/control/Src/modules/RadioModule.cpp
+++ b/robot/control/Src/modules/RadioModule.cpp
@@ -37,6 +37,7 @@ RadioModule::RadioModule(LockedStruct<BatteryVoltage>& batteryVoltage,
     radioErrorLock->isValid = false;
     radioErrorLock->lastUpdate = 0;
     radioErrorLock->hasError = false;
+    radioErrorLock->hasConnectionError = false;
 }
 
 void RadioModule::start() {
@@ -78,6 +79,7 @@ void RadioModule::entry() {
 
         radioErrorLock->isValid = true;
         radioErrorLock->lastUpdate = HAL_GetTick();
-        radioErrorLock->hasError = false;
+        radioErrorLock->hasConnectionError = link.isRadioConnected();
+        radioErrorLock->hasError = radioErrorLock->hasConnectionError;
     }
 }

--- a/robot/control/Src/modules/RadioModule.cpp
+++ b/robot/control/Src/modules/RadioModule.cpp
@@ -36,7 +36,6 @@ RadioModule::RadioModule(LockedStruct<BatteryVoltage>& batteryVoltage,
     auto radioErrorLock = radioError.unsafe_value();
     radioErrorLock->isValid = false;
     radioErrorLock->lastUpdate = 0;
-    radioErrorLock->hasError = false;
     radioErrorLock->hasConnectionError = false;
     radioErrorLock->hasSoccerConnectionError = false;
 }
@@ -44,7 +43,7 @@ RadioModule::RadioModule(LockedStruct<BatteryVoltage>& batteryVoltage,
 void RadioModule::start() {
     link.init();
     printf("INFO: Radio initialized\r\n");
-    radioError.lock()->initialized = true;
+    radioError.lock()->initialized = link.isRadioInitialized();
 }
 
 void RadioModule::entry() {
@@ -82,6 +81,5 @@ void RadioModule::entry() {
         radioErrorLock->lastUpdate = HAL_GetTick();
         radioErrorLock->hasConnectionError = link.isRadioConnected();
         radioErrorLock->hasSoccerConnectionError = link.hasSoccerTimedOut();
-        radioErrorLock->hasError = radioErrorLock->hasConnectionError || radioErrorLock->hasSoccerConnectionError;
     }
 }

--- a/robot/control/Src/radio/RadioLink.cpp
+++ b/robot/control/Src/radio/RadioLink.cpp
@@ -83,5 +83,7 @@ bool RadioLink::receive(KickerCommand& kickerCommand,
     motionCommand.bodyWVel = static_cast<float>(control->bodyW) / rtp::ControlMessage::VELOCITY_SCALE_FACTOR;
     motionCommand.dribbler = control->dribbler;
 
+    radioConnected = true;
+
     return true;
 }

--- a/robot/control/Src/radio/RadioLink.cpp
+++ b/robot/control/Src/radio/RadioLink.cpp
@@ -54,6 +54,7 @@ bool RadioLink::receive(KickerCommand& kickerCommand,
                        MotionCommand& motionCommand) {
     // Make sure there is actually data to read
     if (!radio->isAvailable()) {
+        cyclesWithoutPackets++;
         return false;
     }
 
@@ -61,6 +62,7 @@ bool RadioLink::receive(KickerCommand& kickerCommand,
 
     if (radio->receive(packet.data(), rtp::ForwardSize) != rtp::ForwardSize) {
         // didn't get enough bytes
+        cyclesWithoutPackets++;
         return false;
     }
 
@@ -84,6 +86,6 @@ bool RadioLink::receive(KickerCommand& kickerCommand,
     motionCommand.dribbler = control->dribbler;
 
     radioConnected = true;
-
+    cyclesWithoutPackets = 0;
     return true;
 }

--- a/robot/control/Src/radio/RadioLink.cpp
+++ b/robot/control/Src/radio/RadioLink.cpp
@@ -86,7 +86,6 @@ bool RadioLink::receive(KickerCommand& kickerCommand,
     motionCommand.bodyWVel = static_cast<float>(control->bodyW) / rtp::ControlMessage::VELOCITY_SCALE_FACTOR;
     motionCommand.dribbler = control->dribbler;
 
-    radioConnected = radio->isConnected();
     cyclesWithoutPackets = 0;
     return true;
 }

--- a/robot/control/Src/radio/RadioLink.cpp
+++ b/robot/control/Src/radio/RadioLink.cpp
@@ -18,6 +18,7 @@ void RadioLink::init() {
                                        RADIO_R0_CS,
                                        RADIO_GLB_RST,
                                        RADIO_R0_INT);
+    radioInitialized = radio->isInitialized();
 }
 
 void RadioLink::send(const BatteryVoltage& batteryVoltage,
@@ -85,7 +86,7 @@ bool RadioLink::receive(KickerCommand& kickerCommand,
     motionCommand.bodyWVel = static_cast<float>(control->bodyW) / rtp::ControlMessage::VELOCITY_SCALE_FACTOR;
     motionCommand.dribbler = control->dribbler;
 
-    radioConnected = true;
+    radioConnected = radio->isConnected();
     cyclesWithoutPackets = 0;
     return true;
 }

--- a/robot/control/main.cpp
+++ b/robot/control/main.cpp
@@ -126,7 +126,8 @@ int main() {
                          batteryVoltage,
                          fpgaStatus,
                          kickerInfo,
-                         radioError);
+                         radioError,
+                         imuData);
     createModule(&led);
 
     static FPGAModule fpga(std::move(fpgaSPI),

--- a/robot/lib/Inc/drivers/GenericRadio.hpp
+++ b/robot/lib/Inc/drivers/GenericRadio.hpp
@@ -34,4 +34,14 @@ public:
      * Returns true when there is data to read from the radio
      */
     virtual bool isAvailable() = 0;
+
+    /**
+     * Returns whether the radio is connected to WiFi or not
+     */
+    virtual bool isConnected() = 0;
+
+    /**
+     * Returns whether the radio is properly initialized or not
+     */
+    virtual bool isInitialized() = 0;
 };

--- a/robot/lib/Inc/drivers/ISM43340.hpp
+++ b/robot/lib/Inc/drivers/ISM43340.hpp
@@ -371,7 +371,8 @@ public:
 
     void pingRouter();
 
-    bool isConnected() const { return isInit; }
+    bool isInitialized() const { return isInit; }
+    bool isConnected() { return connected; }
 
     int32_t testPrint();
 
@@ -448,4 +449,5 @@ private:
     uint8_t *cmdStart;
 
     bool isInit = false;
+    bool connected = false;
 };

--- a/robot/lib/Inc/drivers/ISM43340.hpp
+++ b/robot/lib/Inc/drivers/ISM43340.hpp
@@ -371,8 +371,8 @@ public:
 
     void pingRouter();
 
-    bool isInitialized() const { return isInit; }
-    bool isConnected() { return connected; }
+    virtual bool isInitialized() { return isInit; }
+    virtual bool isConnected() { return connected; }
 
     int32_t testPrint();
 

--- a/robot/lib/Src/drivers/ISM43340.cpp
+++ b/robot/lib/Src/drivers/ISM43340.cpp
@@ -382,7 +382,7 @@ void ISM43340::reset() {
     if (readBuffer.size() == 0 || (int)readBuffer[0] == 0) {
         // Failed to connect to network
         // not sure what to have it do here
-
+        connected = false;
         printf("Failed to connect to network\r\n");
         return;
     }
@@ -430,6 +430,6 @@ void ISM43340::reset() {
                 ISMConstants::TYPE_TRANSPORT_CLIENT::ENABLE);
 
     currentSocket = SOCKET_TYPE::SEND;
-
+    connected = true;
     printf("Radio initialized\r\n");
 }

--- a/robot/lib/Src/drivers/ISM43340.cpp
+++ b/robot/lib/Src/drivers/ISM43340.cpp
@@ -307,7 +307,6 @@ void ISM43340::reset() {
 
         radioSPI->frequency(ISMConstants::SPI_FREQ);
 
-        int counter = 0;
         // Wait for device to turn on
         for (int counter = 0; counter < 1500; counter++) {
             vTaskDelay(10);


### PR DESCRIPTION
Added new infrastructure based on adding Error structs of led colors to a cycling queue for the dotStar LEDs. Displaying LED colors while the LEDModule is running is now handled with the queue and the displayErrors() method.
The LEDModule will flash an error on and off for specified counts before moving to the new one