### PR TITLE
LED module deadlock fix

### DIFF
--- a/robot/control/Inc/modules/LEDModule.hpp
+++ b/robot/control/Inc/modules/LEDModule.hpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <array>
 #include <memory>
-#include <vector>
 
 #include "LockedStruct.hpp"
 #include "DigitalOut.hpp"
@@ -57,6 +56,8 @@ struct Error {
     uint32_t led1;
     uint32_t led2;
 };
+
+bool operator==(const Error& e1, const Error& e2);
 
 /**
  * Module interfacing with debugging LEDS based on the statuses of other electronics
@@ -209,11 +210,11 @@ private:
                                              InfoColors::BOOT_FAIL};
 
     const std::array<Error, 6> ERR_LIST = {ERR_RADIO_BOOT_FAIL,
-                                               ERR_RADIO_WIFI_FAIL,
-                                               ERR_RADIO_SOCCER_FAIL,
-                                               ERR_FPGA_BOOT_FAIL,
-                                               ERR_KICKER_BOOT_FAIL,
-                                               ERR_IMU_BOOT_FAIL};
+                                           ERR_RADIO_WIFI_FAIL,
+                                           ERR_RADIO_SOCCER_FAIL,
+                                           ERR_FPGA_BOOT_FAIL,
+                                           ERR_KICKER_BOOT_FAIL,
+                                           ERR_IMU_BOOT_FAIL};
 
     /**
      * Array of toggles whose values indicates where the error at the same index in ERR_LIST is active or not

--- a/robot/control/Src/modules/LEDModule.cpp
+++ b/robot/control/Src/modules/LEDModule.cpp
@@ -218,10 +218,10 @@ void LEDModule::displayErrors() {
 }
 
 void LEDModule::setError(const Error e, bool toggle) {
-    const Error *error = std::find_if(ERR_LIST.begin(), ERR_LIST.end(), [&](Error err) {
-        return err.led0 == e.led0 &&
-               err.led1 == e.led1 &&
-               err.led2 == e.led2;
-    });
-    errToggles.at(std::distance(ERR_LIST.begin(), error)) = toggle;
+    const Error *error = std::find(ERR_LIST.begin(), ERR_LIST.end(), e);
+    if (error == ERR_LIST.end()) {
+        printf("[ERROR] Invalid error code\r\n");
+    } else {
+        errToggles.at(std::distance(ERR_LIST.begin(), error)) = toggle;
+    }
 }

--- a/robot/lib/Src/drivers/AVR910.cpp
+++ b/robot/lib/Src/drivers/AVR910.cpp
@@ -341,7 +341,7 @@ int AVR910::readPartNumber() {
 
 void AVR910::chipErase() {
     auto spi_lock = lock_spi();
-DWT_Delay(10);
+    DWT_Delay(10);
     // Issue chip erase command.
     nCs_->write(0);
     spi_lock->transmit(0xAC);
@@ -388,7 +388,7 @@ void AVR910::loadMemoryPage(int highLow, char address, char data) {
 void AVR910::writeFlashMemoryByte(int highLow, int address, char data) {
     auto spi_lock = lock_spi();
 
-DWT_Delay(10);
+    DWT_Delay(10);
     nCs_->write(0);
     spi_lock->transmit(0x4C);
     spi_lock->transmit(address & 0xFF00 >> 8);
@@ -401,7 +401,7 @@ DWT_Delay(10);
 void AVR910::writeFuseBitsLow() {
     auto spi_lock = lock_spi();
 
-DWT_Delay(10);
+    DWT_Delay(10);
     nCs_->write(0);
     spi_lock->transmit(0xAC);
     spi_lock->transmit(0xA0);

--- a/robot/lib/Src/drivers/KickerBoard.cpp
+++ b/robot/lib/Src/drivers/KickerBoard.cpp
@@ -172,7 +172,6 @@ void KickerBoard::service() {
     DWT_Delay(50);
     nCs_->write(1);
 
-
     _current_voltage = (resp & VOLTAGE_MASK) * VOLTAGE_SCALE;
 
     _ball_sensed = resp & BREAKBEAM_TRIPPED;


### PR DESCRIPTION
The LED module was dying due to some bug in `mtrain-firmware`'s implementation of `SPI::transmit(const std::vector&)`. This fixes that, and removes some unnecessary allocation (changes `std::vector` to `std::array`).