### PR TITLE
Use clang-format instead of clang-format-3.9

### DIFF
--- a/util/ubuntu-packages.txt
+++ b/util/ubuntu-packages.txt
@@ -11,7 +11,7 @@ ccache
 doxygen
 
 # C/C++ (and more) code-formatting tool
-clang-format-3.9
+clang-format
 
 # AVR
 avr-libc


### PR DESCRIPTION
clang-format-3.9 is not available by default on 20.04 and honestly I have had no issues running this on clang-format 10