### PR TITLE
Fix Firmware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 /gmon.out
 *.swp
 /.settings
+*/cmake-*
+
 # ignore the generated docs note the CI system force adds these
 /generated-docs
 *~

--- a/control/include/drivers/RotarySelector.hpp
+++ b/control/include/drivers/RotarySelector.hpp
@@ -35,7 +35,6 @@ public:
         uint8_t reading = 0;
         for (size_t i = 0; i < NUM_PINS; ++i) reading |= m_pins[i].read() << i;
         return reading;
-        // return 1;
     }
 
 private:

--- a/control/include/macro.hpp
+++ b/control/include/macro.hpp
@@ -1,0 +1,33 @@
+#ifndef CONTROL_MACRO_HPP
+#define CONTROL_MACRO_HPP
+#include "FreeRTOS.h"
+#include "FreeRTOSConfig.h"
+#include "delay.h"
+#include "mtrain.hpp"
+#include "robocup.hpp"
+#include "task.h"
+
+/**
+ * @def delay wrapper that considers whether or not the rtos is running
+ * @param time time in FreeRTOS ticks to delay the method
+ */
+static inline void delay_from_tick(uint32_t time) {
+#ifdef USING_RTOS
+    vTaskDelay(time);
+#else
+    DWT_Delay(time * configTICK_RATE_HZ);
+#endif
+}
+
+/**
+ * @def delay wrapper that considers whether or not the rtos is running
+ * @param time time in microseconds to delay the method
+ */
+static inline void delay_from_microseconds(uint32_t time) {
+#ifdef USING_RTOS
+    vTaskDelay(time / configTICK_RATE_HZ);
+#else
+    DWT_Delay(time);
+#endif
+}
+#endif  // CONTROL_MACRO_HPP

--- a/control/include/robocup.hpp
+++ b/control/include/robocup.hpp
@@ -1,0 +1,14 @@
+#ifndef CONTROL_ROBOCUP_HPP
+#define CONTROL_ROBOCUP_HPP
+
+/**
+ * @headerfile global configuration values for robocup firmware are defined here
+ */
+
+/**
+ * @def  Whether or not we are using an RTOS.
+ *       This affects how we should be delaying in some places
+ */
+#define USING_RTOS
+
+#endif  // CONTROL_ROBOCUP_HPP

--- a/control/include/robocup/LockedStruct.hpp
+++ b/control/include/robocup/LockedStruct.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "mtrain.hpp"
+#include <utility>
 
 #include "FreeRTOS.h"
+#include "mtrain.hpp"
 #include "semphr.h"
 #include "task.h"
-#include <utility>
 
 /**
  * A locked-struct abstraction. To access the inner value (either read or write)
@@ -17,19 +17,19 @@
  *
  * @tparam T
  */
-template<typename T>
+template <typename T>
 struct LockedStruct {
 public:
-    template<typename... Args>
+    template <typename... Args>
     LockedStruct(Args... args) : value(std::forward<Args>(args)...) {
         mutex = xSemaphoreCreateRecursiveMutex();
     }
 
     // No copy/move
     LockedStruct(const LockedStruct&) = delete;
-    LockedStruct& operator=(const LockedStruct& ) = delete;
+    LockedStruct& operator=(const LockedStruct&) = delete;
     LockedStruct(LockedStruct&&) = delete;
-    LockedStruct& operator=(LockedStruct&& ) = delete;
+    LockedStruct& operator=(LockedStruct&&) = delete;
 
     ~LockedStruct() {}
 
@@ -42,13 +42,9 @@ public:
         Lock(Lock&& other) = default;
         Lock& operator=(Lock&& other) = default;
 
-        T& value() {
-            return locked->value;
-        }
+        T& value() { return locked->value; }
 
-        T* operator->() {
-            return &(locked->value);
-        }
+        T* operator->() { return &(locked->value); }
 
         ~Lock() {
             locked->mutex_depth--;
@@ -56,7 +52,7 @@ public:
         }
 
     private:
-        Lock(LockedStruct* locked, bool *first_lock) : locked(locked) {
+        Lock(LockedStruct* locked, bool* first_lock) : locked(locked) {
             locked->acquire_mutex();
             if (first_lock) {
                 *first_lock = (locked->mutex_depth == 0);
@@ -72,9 +68,11 @@ public:
      * Lock this struct.
      * @param first_lock [optional] output parameter to determine whether or
      *      not this is the only current lock on this struct.
+     * @param debug_string [optional] output parameter used for keeping track of where the
+     *      lock method was called from
      * @return a lock on this struct.
      */
-    Lock lock(bool *first_lock = nullptr) {
+    Lock lock(bool* first_lock = nullptr, const char* debug_string = nullptr) {
         return Lock(this, first_lock);
     }
 
@@ -89,18 +87,12 @@ public:
      *
      * @return A pointer to the underlying struct
      */
-    T *unsafe_value() {
-        return &value;
-    }
+    T* unsafe_value() { return &value; }
 
 private:
-    void acquire_mutex() {
-        xSemaphoreTakeRecursive(mutex, 100);
-    }
+    void acquire_mutex() { xSemaphoreTakeRecursive(mutex, 100); }
 
-    void release_mutex() {
-        xSemaphoreGiveRecursive(mutex);
-    }
+    void release_mutex() { xSemaphoreGiveRecursive(mutex); }
 
     friend struct Lock;
 
@@ -108,6 +100,6 @@ private:
 
     int mutex_depth = 0;
 
-//    StaticSemaphore_t mutex;
+    //    StaticSemaphore_t mutex;
     SemaphoreHandle_t mutex = nullptr;
 };

--- a/control/include/robocup/modules/LEDModule.hpp
+++ b/control/include/robocup/modules/LEDModule.hpp
@@ -79,7 +79,7 @@ public:
      *
      * Uses the default priority of 1.
      */
-    static constexpr int kPriority = 1;
+    static constexpr int kPriority = 0;
 
     /**
      * Constructor for LEDModule

--- a/control/include/robocup/modules/MotionControlModule.hpp
+++ b/control/include/robocup/modules/MotionControlModule.hpp
@@ -1,20 +1,27 @@
 #pragma once
 
-#include "modules/GenericModule.hpp"
+#include <Eigen/Dense>
+
+#include "LockedStruct.hpp"
 #include "MicroPackets.hpp"
+#include "modules/GenericModule.hpp"
+#include "modules/IMUModule.hpp"
 
 #include "motion-control/DribblerController.hpp"
 #include "motion-control/RobotController.hpp"
 #include "motion-control/RobotEstimator.hpp"
-
-#include <Eigen/Dense>
-#include "LockedStruct.hpp"
 
 /**
  * Module handling robot state estimation and motion control for motors
  */
 class MotionControlModule : public GenericModule {
 public:
+    MotionControlModule(LockedStruct<BatteryVoltage>& batteryVoltage,
+                        LockedStruct<IMUData>& imuData, LockedStruct<MotionCommand>& motionCommand,
+                        LockedStruct<MotorFeedback>& motorFeedback,
+                        LockedStruct<MotorCommand>& motorCommand,
+                        LockedStruct<DebugInfo>& debugInfo, IMUModule& imuModule);
+
     /**
      * Number of times per second (frequency) that MotionControlModule should run (Hz)
      */
@@ -38,12 +45,6 @@ public:
      * @param motorFeedback Shared memory location containing encoder counts and currents to each wheel motor
      * @param motorCommand Shared memory location containing wheel motor duty cycles and dribbler rotation speed
      */
-    MotionControlModule(LockedStruct<BatteryVoltage>& batteryVoltage,
-                        LockedStruct<IMUData>& imuData,
-                        LockedStruct<MotionCommand>& motionCommand,
-                        LockedStruct<MotorFeedback>& motorFeedback,
-                        LockedStruct<MotorCommand>& motorCommand,
-                        LockedStruct<DebugInfo>& debugInfo);
 
     /**
      * Code to run when called by RTOS once per system tick (`kperiod`)
@@ -52,6 +53,8 @@ public:
      * and motor controllers.
      */
     void entry() override;
+
+    void start() override;
 
 private:
     /**
@@ -71,6 +74,8 @@ private:
     RobotEstimator robotEstimator;
 
     Eigen::Matrix<float, 4, 1> prevCommand;
+
+    IMUModule& imuModule;
 
     /**
      * Max amount of time that can elapse from the latest

--- a/control/include/robocup/modules/RadioModule.hpp
+++ b/control/include/robocup/modules/RadioModule.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "LockedStruct.hpp"
-#include "GenericModule.hpp"
-#include "MicroPackets.hpp" 
-#include "radio/RadioLink.hpp"
 #include "DigitalOut.hpp"
+#include "GenericModule.hpp"
+#include "LockedStruct.hpp"
+#include "MicroPackets.hpp"
+#include "radio/RadioLink.hpp"
 
 /**
  * Module interfacing with Radio and handling Radio status
@@ -14,7 +14,7 @@ public:
     /**
      * Number of times per second (frequency) that RadioModule should run (Hz)
      */
-    static constexpr float kFrequency = 50.0f;
+    static constexpr float kFrequency = 120.0f;
 
     /**
      * Number of seconds elapsed (period) between RadioModule runs (milliseconds)
@@ -24,7 +24,7 @@ public:
     /**
      * Priority used by RTOS
      */
-    static constexpr int kPriority = 3;
+    static constexpr int kPriority = 5;
 
     /**
      * Constructor for RadioModule
@@ -74,4 +74,25 @@ private:
      */
     RadioLink link;
     DigitalOut secondRadioCS;
+
+    /**
+     * Send when this mode is even. Receive when it is odd.
+     */
+    uint8_t current_mode;
+
+    /**
+     * Choose an odd divisor to receive more than send.
+     */
+    static constexpr uint8_t mode_divisor = 2;
+
+    // not necessary,
+    // but let's impose that the divisor evenly divides the frequency
+    static_assert((int)kFrequency % mode_divisor == 0,
+                  "The mode divisor should evenly divide the radio module's frequency");
+
+    void fakeEntry();
+    void realEntry();
+
+    void send();
+    void receive();
 };

--- a/control/include/robocup/modules/RotaryDialModule.hpp
+++ b/control/include/robocup/modules/RotaryDialModule.hpp
@@ -25,7 +25,7 @@ public:
     /**
      * Priority used by RTOS
      */
-    static constexpr int kPriority = 3;
+    static constexpr int kPriority = 2;
 
     /**
      * Constructor for RotaryDialModule

--- a/control/include/test/motor.hpp
+++ b/control/include/test/motor.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+/** Change this to true to test motors.
+ * Switches radio to a fake radio that just fills in commands.*/
+constexpr bool run_motor_test = false;
+constexpr float max_vel = 2.0;
+constexpr u_int16_t max_dribbler_val = 127;

--- a/control/src/drivers/ISM43340.cpp
+++ b/control/src/drivers/ISM43340.cpp
@@ -64,11 +64,9 @@ bool ISM43340::isAvailable() {
     for (unsigned int i = 0; i < noData.size(); i++) {
         if (i >= readBuffer.size()) {
             matchNoData = false;
-            // printf("1\r\n");
             break;
         } else if (readBuffer.at(i) != noData.at(i)) {
             matchNoData = false;
-            // printf("2\r\n");
             break;
         }
     }
@@ -77,11 +75,9 @@ bool ISM43340::isAvailable() {
     for (unsigned int i = 0; i < err.size(); i++) {
         if (i >= readBuffer.size()) {
             matchErr = false;
-            // printf("3\r\n");
             break;
         } else if (readBuffer.at(i) != err.at(i)) {
             matchErr = false;
-            // printf("4\r\n");
             break;
         }
     }

--- a/control/src/drivers/ISM43340.cpp
+++ b/control/src/drivers/ISM43340.cpp
@@ -1,13 +1,14 @@
 #include "drivers/ISM43340.hpp"
-#include "delay.h"
-#include <cstring>
-#include "interrupt_in.h"
 
+#include <cstdio>
+#include <cstring>
+#include <string>
 
 #include "FreeRTOS.h"
+#include "delay.h"
+#include "interrupt_in.h"
+#include "macro.hpp"
 #include "task.h"
-#include <string>
-#include <cstdio>
 
 volatile ISMConstants::State currentState;
 
@@ -19,9 +20,9 @@ void dataReady_cb() {
     // In all seriousness, this is just a state machine where we always
     // increment to the next state whenever there is an edge trigger
     // This is basically the `++x % y` that you see
-    currentState =  static_cast<ISMConstants::State>(
-                        (static_cast<uint8_t>(currentState) + 1) %
-                         static_cast<uint8_t>(ISMConstants::State::NumStates));
+    currentState =
+        static_cast<ISMConstants::State>((static_cast<uint8_t>(currentState) + 1) %
+                                         static_cast<uint8_t>(ISMConstants::State::NumStates));
 }
 
 ISM43340::ISM43340(std::unique_ptr<SPI> radioSPI, PinName nCsPin, PinName nResetPin,
@@ -32,7 +33,6 @@ ISM43340::ISM43340(std::unique_ptr<SPI> radioSPI, PinName nCsPin, PinName nReset
       dataReady{dataReadyPin.port, dataReadyPin.pin},
       currentSocket(SOCKET_TYPE::SEND),
       cmdStart(nullptr) {
-
     currentState = ISMConstants::State::CommandReady;
     interruptin_init_ex(dataReady, &dataReady_cb, PULL_DOWN, INTERRUPT_RISING_FALLING);
 
@@ -46,14 +46,14 @@ ISM43340::ISM43340(std::unique_ptr<SPI> radioSPI, PinName nCsPin, PinName nReset
 bool ISM43340::isAvailable() {
     // See if we are already on the correct socket before doing stuff
     if (currentSocket != SOCKET_TYPE::RECEIVE) {
-        sendCommand(ISMConstants::CMD_SET_COMMUNICATION_SOCKET,
-                    ISMConstants::RECEIVE_SOCKET);
+        sendCommand(ISMConstants::CMD_SET_COMMUNICATION_SOCKET, ISMConstants::RECEIVE_SOCKET);
         currentSocket = SOCKET_TYPE::RECEIVE;
     }
 
     // Try to read data from device
     // If there is no data, device returns "\r\n\r\nOK\r\n> "
     // If there is data, device returns raw data
+    // printf("Is there stuff to read? ");
     sendCommand(ISMConstants::CMD_READ_TRANSPORT_DATA);
 
     // Check to see if it's the normal prompt
@@ -64,9 +64,11 @@ bool ISM43340::isAvailable() {
     for (unsigned int i = 0; i < noData.size(); i++) {
         if (i >= readBuffer.size()) {
             matchNoData = false;
+            // printf("1\r\n");
             break;
         } else if (readBuffer.at(i) != noData.at(i)) {
             matchNoData = false;
+            // printf("2\r\n");
             break;
         }
     }
@@ -75,9 +77,11 @@ bool ISM43340::isAvailable() {
     for (unsigned int i = 0; i < err.size(); i++) {
         if (i >= readBuffer.size()) {
             matchErr = false;
+            // printf("3\r\n");
             break;
         } else if (readBuffer.at(i) != err.at(i)) {
             matchErr = false;
+            // printf("4\r\n");
             break;
         }
     }
@@ -103,7 +107,8 @@ unsigned int ISM43340::send(const uint8_t* data, const unsigned int numBytes) {
     uint8_t arg[argSize];
 
     // Num digits written, not including null termination
-    unsigned int numDigitsWritten = snprintf(reinterpret_cast<char*>(&arg[0]), maxNumDigits, "%d", numBytes);
+    unsigned int numDigitsWritten =
+        snprintf(reinterpret_cast<char*>(&arg[0]), maxNumDigits, "%d", numBytes);
 
     // Copy delimiter
     memcpy(&arg[numDigitsWritten], &ISMConstants::ODD_DELIMITER[0], oddDelimiterSize);
@@ -144,10 +149,11 @@ unsigned int ISM43340::receive(uint8_t* data, const unsigned int maxNumBytes) {
  * Let it run for a minute or so to see if it breaks eventually
  */
 void ISM43340::writeToSpi(uint8_t* command, int length) {
-    while (currentState != ISMConstants::State::CommandReady);
+    while (currentState != ISMConstants::State::CommandReady)
+        ;
 
     nCs = ISMConstants::CHIP_SELECT;
-    DWT_Delay(100); // Must be 50 us or more. Measure first response on logic analyzer
+    DWT_Delay(100);  // Must be 50 us or more. Measure first response on logic analyzer
 
     for (int i = 0; i < length; i += 2) {
         uint8_t c1 = command[i];
@@ -164,7 +170,8 @@ void ISM43340::writeToSpi(uint8_t* command, int length) {
     nCs = ISMConstants::CHIP_DESELECT;
 
     // Wait till data ready goes to 0
-    while (currentState != ISMConstants::State::CommandAck);
+    while (currentState != ISMConstants::State::CommandAck)
+        ;
 }
 
 uint32_t ISM43340::readFromSpi() {
@@ -173,10 +180,11 @@ uint32_t ISM43340::readFromSpi() {
     readBuffer.clear();
 
     // Wait till data ready goes to 1
-    while (currentState != ISMConstants::State::ResponseReady);
+    while (currentState != ISMConstants::State::ResponseReady)
+        ;
 
     nCs = ISMConstants::CHIP_SELECT;
-    DWT_Delay(100); // Must be 50 us or more. Measure first response on logic analyzer
+    DWT_Delay(100);  // Must be 50 us or more. Measure first response on logic analyzer
 
     // Once we find any data on the bus
     // 0x25 0x25 is a valid character combination in the packet
@@ -188,11 +196,8 @@ uint32_t ISM43340::readFromSpi() {
 
         // If we read two nacks and we haven't found data yet, quit out
         // otherwise, check if the buffer is full and read it in
-        if (!(data1 == ISMConstants::NACK &&
-              data2 == ISMConstants::NACK &&
-              !foundAnyData) &&
+        if (!(data1 == ISMConstants::NACK && data2 == ISMConstants::NACK && !foundAnyData) &&
             readBuffer.size() < ISMConstants::RECEIVE_BUFF_SIZE) {
-
             // Swap endianess so readBuff is correct order
             readBuffer.push_back(data2);
             readBuffer.push_back(data1);
@@ -207,7 +212,8 @@ uint32_t ISM43340::readFromSpi() {
     return bytesRead;
 }
 
-void ISM43340::sendCommand(const std::string& command, const uint8_t *arg, const unsigned int argSize) {
+void ISM43340::sendCommand(const std::string& command, const uint8_t* arg,
+                           const unsigned int argSize) {
     unsigned int totalLength = 0;
 
     // Add to the cmd struct backwards so the end of the cmd touches the arg
@@ -239,13 +245,11 @@ void ISM43340::sendCommand(const std::string& command, const uint8_t *arg, const
     // "XX=XXXX<CR>" or "XX<CR>"
     if (command.compare("S3=") != 0) {
         if (totalLength % 2 == 0) {
-            memcpy(&cmdStart[totalLength],
-                   &ISMConstants::EVEN_DELIMITER[0],
+            memcpy(&cmdStart[totalLength], &ISMConstants::EVEN_DELIMITER[0],
                    ISMConstants::EVEN_DELIMITER.length());
             totalLength += ISMConstants::EVEN_DELIMITER.length();
         } else {
-            memcpy(&cmdStart[totalLength],
-                   &ISMConstants::ODD_DELIMITER[0],
+            memcpy(&cmdStart[totalLength], &ISMConstants::ODD_DELIMITER[0],
                    ISMConstants::ODD_DELIMITER.length());
             totalLength += ISMConstants::ODD_DELIMITER.length();
         }
@@ -256,14 +260,12 @@ void ISM43340::sendCommand(const std::string& command, const uint8_t *arg, const
 }
 
 void ISM43340::sendCommand(const std::string& command, const std::string& arg) {
-    sendCommand(command,
-                reinterpret_cast<const uint8_t*>(arg.data()),
-                arg.length());
+    sendCommand(command, reinterpret_cast<const uint8_t*>(arg.data()), arg.length());
 }
 
 int32_t ISM43340::testPrint() {
     for (unsigned int i = 0; i < readBuffer.size(); i++) {
-        printf("[INFO] %c", (char) readBuffer[i]);
+        printf("[INFO] %c", (char)readBuffer[i]);
         vTaskDelay(10);
     }
     printf("\r\n");
@@ -302,17 +304,16 @@ void ISM43340::pingRouter() {
 }
 
 void ISM43340::reset() {
-    for(int i = 0; i < 5; i++) {
+    for (int i = 0; i < 5; i++) {
         nReset = ISMConstants::RESET_TURN_OFF;
-        vTaskDelay(ISMConstants::RESET_DELAY);
+        delay_from_tick(ISMConstants::RESET_DELAY);
         nReset = ISMConstants::RESET_TURN_ON;
-        vTaskDelay(ISMConstants::RESET_DELAY);
-
+        delay_from_tick(ISMConstants::RESET_DELAY);
         radioSPI->frequency(ISMConstants::SPI_FREQ);
 
         // Wait for device to turn on
         for (int counter = 0; counter < 1500; counter++) {
-            vTaskDelay(10);
+            delay_from_tick(10);
             if (interruptin_read(dataReady)) {
                 break;
             }
@@ -322,16 +323,12 @@ void ISM43340::reset() {
 
         if (isInit) {
             break;
-            //return;
-        } 
-        else if (i == 4){
+        } else if (i == 4) {
             printf("[ERROR] Failed to initialize radio.\r\n");
-        }
-        else {
+        } else {
             printf("[INFO] Could not initialize radio. Retrying.\r\n");
         }
     }
-
 
     nCs = ISMConstants::CHIP_SELECT;
     DWT_Delay(500);
@@ -346,38 +343,30 @@ void ISM43340::reset() {
 
     sendCommand(ISMConstants::CMD_POWER_MANAGEMENT, "0");
 
-
     // Configure Network
 
     // Disconnect from a network if power doesn't toggle
     sendCommand(ISMConstants::CMD_DISCONNECT_NETWORK);
 
-    sendCommand(ISMConstants::CMD_SET_NETWORK_SSID,
-                ISMConstants::NETWORK_SSID);
+    sendCommand(ISMConstants::CMD_SET_NETWORK_SSID, ISMConstants::NETWORK_SSID);
 
-    sendCommand(ISMConstants::CMD_SET_NETWORK_PASSWORD,
-                ISMConstants::NETWORK_PASSWORD);
+    sendCommand(ISMConstants::CMD_SET_NETWORK_PASSWORD, ISMConstants::NETWORK_PASSWORD);
 
     sendCommand(ISMConstants::CMD_SET_NETWORK_SECURITY_TYPE,
                 ISMConstants::TYPE_NETWORK_SECURITY::WPA2_AES);
 
-    sendCommand(ISMConstants::CMD_SET_NETWORK_DHCP,
-                ISMConstants::TYPE_NETWORK_DHCP::ENABLED);
+    sendCommand(ISMConstants::CMD_SET_NETWORK_DHCP, ISMConstants::TYPE_NETWORK_DHCP::ENABLED);
 
     sendCommand(ISMConstants::CMD_SET_NETWORK_IP_VERSION,
                 ISMConstants::TYPE_NETWORK_IP_VERSION::IPV4);
 
-    sendCommand(ISMConstants::CMD_SET_NETWORK_GATEWAY,
-                ISMConstants::ROUTER_IP);
+    sendCommand(ISMConstants::CMD_SET_NETWORK_GATEWAY, ISMConstants::ROUTER_IP);
 
-    sendCommand(ISMConstants::CMD_SET_NETWORK_PRIMARY_DNS,
-                ISMConstants::ROUTER_IP);
+    sendCommand(ISMConstants::CMD_SET_NETWORK_PRIMARY_DNS, ISMConstants::ROUTER_IP);
 
-    sendCommand(ISMConstants::CMD_SET_NETWORK_SECONDARY_DNS,
-                ISMConstants::ROUTER_IP);
+    sendCommand(ISMConstants::CMD_SET_NETWORK_SECONDARY_DNS, ISMConstants::ROUTER_IP);
 
-    sendCommand(ISMConstants::CMD_SET_NETWORK_JOIN_RETRY_COUNT,
-                "3");
+    sendCommand(ISMConstants::CMD_SET_NETWORK_JOIN_RETRY_COUNT, "3");
 
     sendCommand(ISMConstants::CMD_NETWORK_AUTO_CONNECT,
                 ISMConstants::TYPE_NETWORK_AUTO_CONNECT::AUTO_JOIN_RECONNECT);
@@ -395,8 +384,7 @@ void ISM43340::reset() {
     // Port initialization
     // UDP receive
 
-    sendCommand(ISMConstants::CMD_SET_COMMUNICATION_SOCKET,
-                ISMConstants::RECEIVE_SOCKET);
+    sendCommand(ISMConstants::CMD_SET_COMMUNICATION_SOCKET, ISMConstants::RECEIVE_SOCKET);
 
     sendCommand(ISMConstants::CMD_SET_TRANSPORT_PROTOCOL,
                 ISMConstants::TYPE_TRANSPORT_PROTOCOL::UDP_ENABLED);
@@ -404,8 +392,7 @@ void ISM43340::reset() {
     sendCommand(ISMConstants::CMD_SET_TRANSPORT_REMOTE_HOST_IP_ADDRESS,
                 ISMConstants::BASE_STATION_IP);
 
-    sendCommand(ISMConstants::CMD_SET_TRANSPORT_REMOTE_PORT_NUMBER,
-                ISMConstants::LOCAL_PORT);
+    sendCommand(ISMConstants::CMD_SET_TRANSPORT_REMOTE_PORT_NUMBER, ISMConstants::LOCAL_PORT);
 
     sendCommand(ISMConstants::CMD_SET_READ_TRANSPORT_PACKET_SIZE, "12");
 
@@ -416,11 +403,9 @@ void ISM43340::reset() {
     sendCommand(ISMConstants::CMD_START_STOP_TRANSPORT_CLIENT,
                 ISMConstants::TYPE_TRANSPORT_CLIENT::ENABLE);
 
-
     // UDP send
 
-    sendCommand(ISMConstants::CMD_SET_COMMUNICATION_SOCKET,
-                ISMConstants::SEND_SOCKET);
+    sendCommand(ISMConstants::CMD_SET_COMMUNICATION_SOCKET, ISMConstants::SEND_SOCKET);
 
     sendCommand(ISMConstants::CMD_SET_TRANSPORT_PROTOCOL,
                 ISMConstants::TYPE_TRANSPORT_PROTOCOL::UDP_ENABLED);

--- a/control/src/robocup/main.cpp
+++ b/control/src/robocup/main.cpp
@@ -122,14 +122,14 @@ int main() {
 
     static LockedStruct<MCP23017> ioExpander(MCP23017{sharedI2C, 0x42});
 
-    static LEDModule led(ioExpander,
+    /*static LEDModule led(ioExpander,
                          sharedSPI,
                          batteryVoltage,
                          fpgaStatus,
                          kickerInfo,
                          radioError,
                          imuData);
-    createModule(&led);
+    createModule(&led);*/
 
     static FPGAModule fpga(std::move(fpgaSPI),
                            motorCommand,
@@ -159,16 +159,11 @@ int main() {
                                  robotID);
     createModule(&dial);
 
-    static MotionControlModule motion(batteryVoltage,
-                                      imuData,
-                                      motionCommand,
-                                      motorFeedback,
-                                      motorCommand,
-                                      debugInfo);
-    createModule(&motion);
-
     static IMUModule imu(sharedSPI, imuData);
-    createModule(&imu);
+
+    static MotionControlModule motion(batteryVoltage, imuData, motionCommand, motorFeedback,
+                                      motorCommand, debugInfo, imu);
+    createModule(&motion);
 
     ////////////////////////////////////////////
 

--- a/control/src/robocup/modules/BatteryModule.cpp
+++ b/control/src/robocup/modules/BatteryModule.cpp
@@ -19,10 +19,10 @@ BatteryModule::BatteryModule(LockedStruct<BatteryVoltage>& batteryVoltage)
 }
 
 void BatteryModule::entry(void) {
-    battery.update();
-    printf("[INFO] Battery Voltage Percentage: %f\r\n", 100*battery.getBattPercentage());
-
     auto batteryLock = batteryVoltage.lock();
+    battery.update();
+    printf("[INFO] Battery Voltage Percentage: %f\r\n", 100 * battery.getBattPercentage());
+
     batteryLock->isValid = true;
     batteryLock->lastUpdate = HAL_GetTick();
     batteryLock->rawVoltage = battery.getRaw();

--- a/control/src/robocup/modules/FPGAModule.cpp
+++ b/control/src/robocup/modules/FPGAModule.cpp
@@ -67,6 +67,7 @@ void FPGAModule::entry() {
 
     {
         auto motorCommandLock = motorCommand.lock();
+        //printf("FPGAOld: %lu, FPGADiff: %lu\r\n", motorCommandLock->lastUpdate, HAL_GetTick() - motorCommandLock->lastUpdate);
         // Make sure commands are valid
         // If they are not valid, we automatically send a 0 duty cycle
         if (motorCommandLock->isValid &&

--- a/control/src/robocup/modules/FPGAModule.cpp
+++ b/control/src/robocup/modules/FPGAModule.cpp
@@ -67,7 +67,8 @@ void FPGAModule::entry() {
 
     {
         auto motorCommandLock = motorCommand.lock();
-        //printf("FPGAOld: %lu, FPGADiff: %lu\r\n", motorCommandLock->lastUpdate, HAL_GetTick() - motorCommandLock->lastUpdate);
+        // printf("FPGAOld: %lu, FPGADiff: %lu\r\n", motorCommandLock->lastUpdate, HAL_GetTick() -
+        // motorCommandLock->lastUpdate);
         // Make sure commands are valid
         // If they are not valid, we automatically send a 0 duty cycle
         if (motorCommandLock->isValid &&

--- a/control/src/robocup/modules/IMUModule.cpp
+++ b/control/src/robocup/modules/IMUModule.cpp
@@ -23,9 +23,9 @@ void IMUModule::start() {
 }
 
 void IMUModule::entry(void) {
+    auto imuDataLock = imuData.lock();
     float rate = imu.gyro_z();
 
-    auto imuDataLock = imuData.lock();
     imuDataLock->isValid = true;
     imuDataLock->lastUpdate = xTaskGetTickCount();
 

--- a/control/src/robocup/modules/MotionControlModule.cpp
+++ b/control/src/robocup/modules/MotionControlModule.cpp
@@ -1,26 +1,30 @@
 #include "modules/MotionControlModule.hpp"
-#include "mtrain.hpp"
-#include "rc-fshare/robot_model.hpp"
-#include <math.h>
-#include "MicroPackets.hpp"
-#include "DigitalOut.hpp"
+
 #include <algorithm>
+
+#include "DigitalOut.hpp"
+#include "MicroPackets.hpp"
+#include "mtrain.hpp"
+
+#include "rc-fshare/robot_model.hpp"
 
 MotionControlModule::MotionControlModule(LockedStruct<BatteryVoltage>& batteryVoltage,
                                          LockedStruct<IMUData>& imuData,
                                          LockedStruct<MotionCommand>& motionCommand,
                                          LockedStruct<MotorFeedback>& motorFeedback,
                                          LockedStruct<MotorCommand>& motorCommand,
-                                         LockedStruct<DebugInfo>& debugInfo)
+                                         LockedStruct<DebugInfo>& debugInfo, IMUModule& imuModule)
     : GenericModule(kPeriod, "motion", kPriority, 1024),
-      batteryVoltage(batteryVoltage), imuData(imuData),
-      motionCommand(motionCommand), motorFeedback(motorFeedback),
+      batteryVoltage(batteryVoltage),
+      imuData(imuData),
+      motionCommand(motionCommand),
+      motorFeedback(motorFeedback),
       motorCommand(motorCommand),
       debugInfo(debugInfo),
       dribblerController(kPeriod.count()),
       robotController(kPeriod.count() * 1000),
-      robotEstimator(kPeriod.count() * 1000) {
-
+      robotEstimator(kPeriod.count() * 1000),
+      imuModule(imuModule) {
     prevCommand << 0, 0, 0, 0;
 
     auto motorCommandLock = motorCommand.unsafe_value();
@@ -32,23 +36,26 @@ MotionControlModule::MotionControlModule(LockedStruct<BatteryVoltage>& batteryVo
     motorCommandLock->dribbler = 0;
 }
 
+void MotionControlModule::start() { imuModule.start(); }
+
 void MotionControlModule::entry() {
-    auto motionCommandLock = motionCommand.lock();
-    auto motorCommandLock = motorCommand.lock();
-    auto motorFeedbackLock = motorFeedback.lock();
-    auto imuDataLock = imuData.lock();
-    auto batteryVoltageLock = batteryVoltage.lock();
+    auto battery = batteryVoltage.lock().value();
+    auto motion_command = motionCommand.lock().value();
+    auto motor_command = motorCommand.lock().value();
+    auto motor_feedback = motorFeedback.lock().value();
+    imuModule.entry();
+    auto imu_data = imuData.lock().value();
 
     DebugFrame frame;
     frame.ticks = xTaskGetTickCount();
-    frame.gyro_z = imuDataLock->omegas[2];
-    frame.accel_x = imuDataLock->accelerations[0];
-    frame.accel_y = imuDataLock->accelerations[1];
+    frame.gyro_z = imu_data.omegas[2];
+    frame.accel_x = imu_data.accelerations[0];
+    frame.accel_y = imu_data.accelerations[1];
 
     // No radio comm in a little while. Return and die.
-    if (!motionCommandLock->isValid || !isRecentUpdate(motionCommandLock->lastUpdate)) {
-        motorCommandLock->isValid = false;
-        motorCommandLock->lastUpdate = HAL_GetTick();
+    if (!motor_command.isValid || !isRecentUpdate(motion_command.lastUpdate)) {
+        motor_command.isValid = false;
+        motor_command.lastUpdate = HAL_GetTick();
     }
 
     // Fill data from shared mem
@@ -57,11 +64,11 @@ void MotionControlModule::entry() {
     measurements << 0, 0, 0, 0, 0;
     currentWheels << 0, 0, 0, 0;
 
-    if (motorFeedbackLock->isValid && isRecentUpdate(motorFeedbackLock->lastUpdate)) {
+    if (motor_feedback.isValid && isRecentUpdate(motor_feedback.lastUpdate)) {
         for (int i = 0; i < 4; i++) {
-            if (!isnan(measurements(i,0))) {
-                measurements(i, 0) = motorFeedbackLock->encoders[i];
-                currentWheels(i, 0) = motorFeedbackLock->encoders[i];
+            if (!std::isnan(measurements(i, 0))) {
+                measurements(i, 0) = motor_feedback.encoders[i];
+                currentWheels(i, 0) = motor_feedback.encoders[i];
             } else {
                 measurements(i, 0) = 0;
                 currentWheels(i, 0) = 0;
@@ -69,23 +76,20 @@ void MotionControlModule::entry() {
         }
     }
 
-    if (imuDataLock->isValid && isRecentUpdate(imuDataLock->lastUpdate)) {
-        measurements(4, 0) = imuDataLock->omegas[2]; // Z gyro
+    if (imu_data.isValid && isRecentUpdate(imu_data.lastUpdate)) {
+        measurements(4, 0) = imu_data.omegas[2];  // Z gyro
     }
 
     // Update targets
     Eigen::Matrix<float, 3, 1> targetState;
     targetState << 0, 0, 0;
 
-    if (motionCommandLock->isValid && isRecentUpdate(motionCommandLock->lastUpdate)) {
-        targetState << motionCommandLock->bodyXVel,
-                       motionCommandLock->bodyYVel,
-                       motionCommandLock->bodyWVel;
+    if (motion_command.isValid && isRecentUpdate(motion_command.lastUpdate)) {
+        targetState << motion_command.bodyXVel, motion_command.bodyYVel, motion_command.bodyWVel;
     }
 
     // Run estimators
     robotEstimator.predict(prevCommand);
-
 
     // Only use the feedback if we have good inputs
     // NAN's most likely came from the divide by dt in the fpga
@@ -93,12 +97,10 @@ void MotionControlModule::entry() {
     // Leaving this hear until someone can test, then remove
     // this
     // - Joe Aug 2019
-    if (motorFeedbackLock->isValid && // imuData->isValid &&
-        !isnan(measurements(0,0)) &&
-        !isnan(measurements(1,0)) &&
-        !isnan(measurements(2,0)) &&
-        !isnan(measurements(3,0)) &&
-        !isnan(measurements(4,0))) {
+    if (motor_feedback.isValid &&  // imuData->isValid &&
+        !std::isnan(measurements(0, 0)) && !std::isnan(measurements(1, 0)) &&
+        !std::isnan(measurements(2, 0)) && !std::isnan(measurements(3, 0)) &&
+        !std::isnan(measurements(4, 0))) {
         robotEstimator.update(measurements);
     } else {
         // Assume we're stopped.
@@ -114,7 +116,7 @@ void MotionControlModule::entry() {
 
     // Run controllers
     uint8_t dribblerCommand = 0;
-    dribblerController.calculate(motionCommandLock->dribbler, dribblerCommand);
+    dribblerController.calculate(motion_command.dribbler, dribblerCommand);
 
     Eigen::Matrix<float, 4, 1> targetWheels;
     Eigen::Matrix<float, 4, 1> motorCommands;
@@ -124,32 +126,34 @@ void MotionControlModule::entry() {
 
     prevCommand = motorCommands;
 
-    motorCommandLock->isValid = true;
-    motorCommandLock->lastUpdate = HAL_GetTick();
+    motor_command.isValid = true;
+    // printf("MotionControlOld: %lu, MotionControlDiff: %lu\r\n", motor_command.lastUpdate, HAL_GetTick() - motor_command.lastUpdate);
+    motor_command.lastUpdate = HAL_GetTick();
 
     // Good to run motors
-    // todo Check stall and motor errors?
-    if (batteryVoltageLock->isValid && !batteryVoltageLock->isCritical) {
-
+    if (battery.isValid && !battery.isCritical) {
         // set motors to real targets
         for (int i = 0; i < 4; i++) {
-            motorCommandLock->wheels[i] = motorCommands(i, 0);
+            motor_command.wheels[i] = motorCommands(i, 0);
         }
-        motorCommandLock->dribbler = dribblerCommand;
+        motor_command.dribbler = dribblerCommand;
     } else {
-
         // rip battery
         // stop
         for (int i = 0; i < 4; i++) {
-            motorCommandLock->wheels[i] = 0.0f;
+            motor_command.wheels[i] = 0.0f;
         }
-        motorCommandLock->dribbler = 0;
+        motor_command.dribbler = 0;
     }
+    motor_command.dribbler = dribblerCommand;
 
     for (int i = 0; i < 4; i++) {
-        frame.motor_outputs[i] = static_cast<int16_t>(motorCommandLock->wheels[i] * 511);
+        frame.motor_outputs[i] = static_cast<int16_t>(motor_command.wheels[i] * 511);
         frame.encDeltas[i] = static_cast<int16_t>(currentWheels(i));
     }
+
+    auto motorCommandLock = motorCommand.lock();
+    motorCommandLock.value() = motor_command;
 
 #if 0
     auto debugInfoLock = debugInfo.lock();
@@ -159,7 +163,6 @@ void MotionControlModule::entry() {
     }
 #endif
 }
-
 bool MotionControlModule::isRecentUpdate(uint32_t lastUpdateTime) {
     return (HAL_GetTick() - lastUpdateTime) < COMMAND_TIMEOUT;
 }

--- a/control/src/robocup/modules/MotionControlModule.cpp
+++ b/control/src/robocup/modules/MotionControlModule.cpp
@@ -94,7 +94,7 @@ void MotionControlModule::entry() {
     // Only use the feedback if we have good inputs
     // NAN's most likely came from the divide by dt in the fpga
     // which was 0, resulting in bad behavior
-    // Leaving this hear until someone can test, then remove
+    // Leaving this here until someone can test, then remove
     // this
     // - Joe Aug 2019
     if (motor_feedback.isValid &&  // imuData->isValid &&

--- a/control/src/robocup/modules/MotionControlModule.cpp
+++ b/control/src/robocup/modules/MotionControlModule.cpp
@@ -127,7 +127,8 @@ void MotionControlModule::entry() {
     prevCommand = motorCommands;
 
     motor_command.isValid = true;
-    // printf("MotionControlOld: %lu, MotionControlDiff: %lu\r\n", motor_command.lastUpdate, HAL_GetTick() - motor_command.lastUpdate);
+    // printf("MotionControlOld: %lu, MotionControlDiff: %lu\r\n", motor_command.lastUpdate,
+    // HAL_GetTick() - motor_command.lastUpdate);
     motor_command.lastUpdate = HAL_GetTick();
 
     // Good to run motors

--- a/control/src/robocup/modules/RadioModule.cpp
+++ b/control/src/robocup/modules/RadioModule.cpp
@@ -133,7 +133,7 @@ void RadioModule::receive() {
         vTaskSuspendAll();
         while (link.receive(received_kicker_command, received_motion_command))
             ;
-        printf("RadioRaw: %lu\r\n", HAL_GetTick());
+        // printf("RadioRaw: %lu\r\n", HAL_GetTick());
         xTaskResumeAll();
 
         if (received_motion_command.isValid) {

--- a/control/src/robocup/modules/RadioModule.cpp
+++ b/control/src/robocup/modules/RadioModule.cpp
@@ -117,7 +117,7 @@ void RadioModule::send() {
     if (battery.isValid && fpga.isValid && id.isValid) {
         vTaskSuspendAll();
         link.send(battery, fpga, kicker, id, debug);
-        //printf("\x1B[32m [INFO] Radio sent information \x1B[37m\r\n");
+        // printf("\x1B[32m [INFO] Radio sent information \x1B[37m\r\n");
         xTaskResumeAll();
     }
 }
@@ -135,7 +135,6 @@ void RadioModule::receive() {
             ;
         printf("RadioRaw: %lu\r\n", HAL_GetTick());
         xTaskResumeAll();
-
 
         if (received_motion_command.isValid) {
             motionCommand.lock().value() = received_motion_command;

--- a/control/src/robocup/modules/RadioModule.cpp
+++ b/control/src/robocup/modules/RadioModule.cpp
@@ -1,22 +1,26 @@
 #include "modules/RadioModule.hpp"
+
+#include "FreeRTOS.h"
 #include "iodefs.h"
+#include "test/motor.hpp"
 
 RadioModule::RadioModule(LockedStruct<BatteryVoltage>& batteryVoltage,
-                         LockedStruct<FPGAStatus>& fpgaStatus,
-                         LockedStruct<KickerInfo>& kickerInfo,
-                         LockedStruct<RobotID>& robotID,
-                         LockedStruct<KickerCommand>& kickerCommand,
+                         LockedStruct<FPGAStatus>& fpgaStatus, LockedStruct<KickerInfo>& kickerInfo,
+                         LockedStruct<RobotID>& robotID, LockedStruct<KickerCommand>& kickerCommand,
                          LockedStruct<MotionCommand>& motionCommand,
-                         LockedStruct<RadioError>& radioError,
-                         LockedStruct<DebugInfo>& debugInfo)
+                         LockedStruct<RadioError>& radioError, LockedStruct<DebugInfo>& debugInfo)
     : GenericModule(kPeriod, "radio", kPriority),
-      batteryVoltage(batteryVoltage), fpgaStatus(fpgaStatus),
-      kickerInfo(kickerInfo), robotID(robotID),
-      kickerCommand(kickerCommand), motionCommand(motionCommand),
+      batteryVoltage(batteryVoltage),
+      fpgaStatus(fpgaStatus),
+      kickerInfo(kickerInfo),
+      robotID(robotID),
+      kickerCommand(kickerCommand),
+      motionCommand(motionCommand),
       radioError(radioError),
-      debugInfo(debugInfo), link(),
-      secondRadioCS(RADIO_R1_CS) {
-
+      debugInfo(debugInfo),
+      link(),
+      secondRadioCS(RADIO_R1_CS),
+      current_mode(0) {
     secondRadioCS = 1;
 
     // todo fill out more kicker stuff
@@ -49,12 +53,56 @@ void RadioModule::start() {
 }
 
 void RadioModule::entry() {
+    if constexpr (run_motor_test) {
+        fakeEntry();
+    } else {
+        realEntry();
+    }
+}
+
+void RadioModule::realEntry() {
+    const auto which_mode = [this]() {
+        this->current_mode = (this->current_mode + 1) % mode_divisor;
+        return this->current_mode;
+    };
+    const auto is_turn_to_send = [&which_mode]() { return which_mode() % 2 != 0; };
+    if (is_turn_to_send()) {
+        send();
+    } else {
+        receive();
+    }
+}
+
+void RadioModule::fakeEntry() {
+    RobotID id;
+
+    { id = robotID.lock().value(); }
+
+    MotionCommand motion_command;
+    KickerCommand kicker_command;
+
+    float scale = ((id.robotID ^ 8) - 8) % 8 / 8.0;
+    motion_command.bodyXVel = max_vel * scale;
+    motion_command.bodyYVel = 0.0;
+    motion_command.bodyWVel = 0.0;
+    motion_command.dribbler = std::abs(max_dribbler_val * scale);
+    motion_command.lastUpdate = HAL_GetTick();
+    motion_command.isValid = true;
+    motionCommand.lock().value() = motion_command;
+
+    kicker_command.lastUpdate = HAL_GetTick();
+    kicker_command.shootMode = KickerCommand::ShootMode::KICK;
+    kicker_command.triggerMode = KickerCommand::TriggerMode::OFF;
+    kicker_command.isValid = true;
+    kickerCommand.lock().value() = kicker_command;
+}
+
+void RadioModule::send() {
     BatteryVoltage battery;
     FPGAStatus fpga;
     RobotID id;
     KickerInfo kicker;
     DebugInfo debug;
-
     {
         battery = batteryVoltage.lock().value();
         fpga = fpgaStatus.lock().value();
@@ -67,28 +115,42 @@ void RadioModule::entry() {
     // That way we don't conflict with other robots on the network
     // that are working
     if (battery.isValid && fpga.isValid && id.isValid) {
+        vTaskSuspendAll();
         link.send(battery, fpga, kicker, id, debug);
+        //printf("\x1B[32m [INFO] Radio sent information \x1B[37m\r\n");
+        xTaskResumeAll();
     }
+}
 
+void RadioModule::receive() {
     {
-        auto motionCommandLock = motionCommand.lock();
-        auto radioErrorLock = radioError.lock();
-        auto kickerCommandLock = kickerCommand.lock();
+        MotionCommand received_motion_command;
+        KickerCommand received_kicker_command;
 
         // Try read
-        // Clear buffer of old packets such that we can get the lastest packet
+        // Clear buffer of old packets such that we can get the latest packet
         // If you don't do this there is a significant lag of 300ms or more
-        while (link.receive(kickerCommandLock.value(), motionCommandLock.value())) {
-            kickerCommandLock->isValid = true;
-            kickerCommandLock->lastUpdate = HAL_GetTick();
+        vTaskSuspendAll();
+        while (link.receive(received_kicker_command, received_motion_command))
+            ;
+        printf("RadioRaw: %lu\r\n", HAL_GetTick());
+        xTaskResumeAll();
 
-            motionCommandLock->isValid = true;
-            motionCommandLock->lastUpdate = HAL_GetTick();
+
+        if (received_motion_command.isValid) {
+            motionCommand.lock().value() = received_motion_command;
         }
 
-        radioErrorLock->isValid = true;
-        radioErrorLock->lastUpdate = HAL_GetTick();
-        radioErrorLock->hasConnectionError = link.isRadioConnected();
-        radioErrorLock->hasSoccerConnectionError = link.hasSoccerTimedOut();
+        if (received_kicker_command.isValid) {
+            kickerCommand.lock().value() = received_kicker_command;
+        }
+
+        {
+            auto radioErrorLock = radioError.lock();
+            radioErrorLock->isValid = true;
+            radioErrorLock->lastUpdate = HAL_GetTick();
+            radioErrorLock->hasConnectionError = link.isRadioConnected();
+            radioErrorLock->hasSoccerConnectionError = link.hasSoccerTimedOut();
+        }
     }
 }

--- a/control/src/robocup/modules/RotaryDialModule.cpp
+++ b/control/src/robocup/modules/RotaryDialModule.cpp
@@ -7,6 +7,9 @@ RotaryDialModule::RotaryDialModule(LockedStruct<MCP23017>& ioExpander, LockedStr
             IOExpanderDigitalInOut(ioExpander, HEX_SWITCH_BIT1, MCP23017::DIR_INPUT),
             IOExpanderDigitalInOut(ioExpander, HEX_SWITCH_BIT2, MCP23017::DIR_INPUT),
             IOExpanderDigitalInOut(ioExpander, HEX_SWITCH_BIT3, MCP23017::DIR_INPUT)}) {
+    auto ioExpanderLock = ioExpander.lock();
+    ioExpanderLock->init();
+    ioExpanderLock->config(0x00FF, 0x00FF, 0x00FF);
 
     auto robotLock = robotID.unsafe_value();
     robotLock->isValid = false;
@@ -21,9 +24,9 @@ void RotaryDialModule::start() {
 void RotaryDialModule::entry(void) {
     int new_robot_id = dial.read();
 
-    //printf("Rotary dial: %d\r\n", new_robot_id);
-
+    printf("Rotary dial: %d\r\n", new_robot_id);
     auto robotIDLock = robotID.lock();
+
     if (last_robot_id == new_robot_id) {
         robotIDLock->isValid = true;
         robotIDLock->lastUpdate = HAL_GetTick();

--- a/control/src/robocup/radio/RadioLink.cpp
+++ b/control/src/robocup/radio/RadioLink.cpp
@@ -73,6 +73,7 @@ bool RadioLink::receive(KickerCommand& kickerCommand,
                        MotionCommand& motionCommand) {
     // Make sure there is actually data to read
     if (!radio->isAvailable()) {
+        printf("[WARNING] Radio says nothing to read\r\n");
         cyclesWithoutPackets++;
         return false;
     }
@@ -81,6 +82,7 @@ bool RadioLink::receive(KickerCommand& kickerCommand,
 
     if (radio->receive(packet.data(), rtp::ForwardSize) != rtp::ForwardSize) {
         // didn't get enough bytes
+        printf("[WARNING] Did not get enough bytes\r\n");
         cyclesWithoutPackets++;
         return false;
     }
@@ -106,5 +108,6 @@ bool RadioLink::receive(KickerCommand& kickerCommand,
 
     cyclesWithoutPackets = 0;
     radioConnected = radio->isConnected();
+    printf("[INFO] Radio Link says we received, %f\r\n", motionCommand.bodyXVel);
     return true;
 }

--- a/control/test/radio-test.cpp
+++ b/control/test/radio-test.cpp
@@ -1,30 +1,30 @@
-#include "mtrain.hpp"
-#include "SPI.hpp"
 #include <optional>
 
-#include "drivers/ISM43340.hpp"
+#include "SPI.hpp"
 #include "bsp.h"
+#include "delay.h"
+#include "drivers/ISM43340.hpp"
+#include "macro.hpp"
+#include "mtrain.hpp"
+#include "radio/RadioLink.hpp"
+
+#undef USING_RTOS
 
 int main() {
-  //   DigitalOut l1 = DigitalOut(LED1);
+    std::unique_ptr radioSPI = std::make_unique<SPI>(SpiBus5, std::nullopt, 16'000'000);
+    auto radioDriver =
+        std::make_unique<ISM43340>(std::move(radioSPI), RADIO_R0_CS, RADIO_GLB_RST, RADIO_R0_INT);
 
-  //   l1 = 1;
+    const char* data = "hello world";
+    const unsigned int num_bytes = strlen(data);
 
-  //   LOG(LOG_INFO, LOG_MAIN, "Starting\r\n");
+    char buffer[1024];
 
-
-  //   fflush(stdout);
-
-  //   std::shared_ptr<SPI> radioSPI = std::make_shared<SPI>(SpiBus5, std::nullopt, 1'000'000);
-  //   ISM43340 radioDriver(radioSPI, p17, p19, p30);
-
-  //   radioDriver.pingRouter();
-  //   radioDriver.testPrint();
-
-  //   LOG(LOG_INFO, LOG_MAIN, "Finished\r\n");
-
-  // while (true) {
-  //     l1.toggle();
-  //     HAL_Delay(100);
-  // }
+    while (true) {
+        delay_from_microseconds(1000);
+        if (radioDriver->isAvailable()) {
+            int num = radioDriver->receive((unsigned char*)buffer, 1024);
+            radioDriver->send((uint8_t*)buffer, num);
+        }
+    }
 }

--- a/control/test/radio_test.py
+++ b/control/test/radio_test.py
@@ -1,5 +1,4 @@
 import socket
-import time
 
 # field computer
 local_ip = "172.16.1.76"

--- a/control/test/radio_test.py
+++ b/control/test/radio_test.py
@@ -1,0 +1,25 @@
+import socket
+import time
+
+# field computer
+local_ip = "172.16.1.76"
+local_port = 25565
+buf_size = 1024
+
+server_msg = "hellorobot!"
+bytes_to_send = str.encode(server_msg)
+
+udp_socket = socket.socket(family=socket.AF_INET, type=socket.SOCK_DGRAM)
+udp_socket.bind((local_ip, local_port))
+
+print(f"UDP server up and listening at {local_ip}@{local_port}")
+
+# change to robot ip
+send_to_addr = "172.16.1.10"
+send_to_port = 25566
+
+while True:
+    udp_socket.sendto(bytes_to_send, (send_to_addr, send_to_port))
+
+    msg, addr = udp_socket.recvfrom(buf_size)
+    print(f"received {msg} from {addr}")

--- a/makefile
+++ b/makefile
@@ -56,6 +56,5 @@ clean:
 CLANG_FORMAT_BINARY=clang-format-10
 
 # run locally before committing
-#pretty-lines:
-#	@git diff $(DIFFBASE) -U0 --no-color | python3 util/style/clang-format-diff.py -binary $(CLANG_FORMAT_BINARY) -i -p1
-#	@git diff -U0 --no-color $(DIFFBASE) | black . --exclude "control/mtrain/"
+pretty-lines:
+	@git diff $(DIFFBASE) -U0 --no-color | python3 util/style/clang-format-diff.py -binary $(CLANG_FORMAT_BINARY) -i -p1


### PR DESCRIPTION
#158 but better. Firmware is actually mostly fixed now.
There are some outstanding issues that we can fix this year, the goal of this pr is just to make master usable again.

- Prevents radio from being preempted while receiving and thus always returning no data available.
- Acquires locks in a consistent order (the rtos locks will timeout after a while so that's not the main deadlocking issue; it needed to be fixed though).
- pretty sure there's still a radio state machine bug especially if it gets preempted by the RTOS. We can fix that by adding a timeout to those infinite while loops. But right now it is unlikely it will emerge since the scheduler is disabled during radio critical sections.
- Add motor test (see motor test hpp cause I was too lazy to create a non-rtos version)
- create new radio test (this doesn't require the rtos, only radio module, mTrain, and a configured computer are needed). Use corresponding python script that Will made to check if both send and receive are working at the driver level.
- Runs radio more often and **do not do both send and receive in the same entry** to keep the RadioModule entry short. 
- many other small improvements (like combining motion control and imu modules) 
- Eviscerate LED Module